### PR TITLE
Fix: Balance easy mode final boss and show all levels

### DIFF
--- a/game.js
+++ b/game.js
@@ -1138,7 +1138,7 @@ function STAGE_NEXUS(){
     ]
   };
 }
-const STAGES = [STAGE_DRIFT, STAGE_CLUSTER, STAGE_FRACTURE, STAGE_SOLAR, STAGE_ECLIPSE, STAGE_VORTEX, STAGE_SURGE, STAGE_INFERNO, STAGE_NEXUS];
+const STAGES = [STAGE_DRIFT, STAGE_CLUSTER, STAGE_FRACTURE, STAGE_SOLAR, STAGE_VORTEX, STAGE_SURGE, STAGE_INFERNO, STAGE_NEXUS, STAGE_ECLIPSE];
 
 // helper for spawn shapes
 function spawnShape(game, spec){
@@ -1308,7 +1308,10 @@ class Game {
       this.shake(e.kind==='mid'?5:3, 0.12);
       // power-up drop
       if (Math.random() < (e.kind==='mid' ? 0.18 : 0.08)){
-        this.spawnPowerUp(e.x, e.y, pick([PU.TRIPLE, PU.SHIELD, PU.BOMB, PU.LIFE]));
+        const dropPool = this.difficulty === 'easy'
+          ? [PU.TRIPLE, PU.SHIELD, PU.BOMB]
+          : [PU.TRIPLE, PU.SHIELD, PU.BOMB, PU.LIFE];
+        this.spawnPowerUp(e.x, e.y, pick(dropPool));
       }
     }
   }
@@ -1785,7 +1788,7 @@ class Game {
     // stage
     ctx.textAlign='right';
     ctx.fillStyle = NEON.cyan;
-    ctx.fillText(this.stage ? this.stage.name : '', W-16, 19);
+    ctx.fillText(this.stage ? `${this.stage.name}  ${this.stageIdx+1}/${STAGES.length}` : '', W-16, 19);
 
     // bottom bar
     ctx.font = 'bold 12px ui-monospace, Menlo, monospace';


### PR DESCRIPTION
## Summary

This PR fixes two gameplay issues on the feature/difficulty-and-lifepowerup branch:

- **Unreachable levels**: Players never see stages VI through IX because the final boss (ECLIPSE) was positioned at stage 5, ending the game immediately. Now ECLIPSE is moved to be the final (9th) stage, allowing all levels to be played in sequence.
- **Easy mode balance**: Easy mode was too forgiving with excessive LIFE power-ups dropping during the final boss fight, combined with starting 5 lives. Removed LIFE from the random power-up pool in easy mode to provide appropriate challenge while keeping the mode accessible.

## Changes

1. **Reorder STAGES array**: Move ECLIPSE from position 5 to position 9 (last stage)
2. **Add HUD progress indicator**: Show stage counter (e.g., "V // ECLIPSE  5/9") so players see all available levels
3. **Balance power-ups in easy mode**: Remove LIFE from easy-mode random drop pool (easy already gets 5 starting lives as a difficulty modifier)

## Testing

- ✅ Select Easy difficulty
- ✅ Verify stages progress I → IX with stage counter visible (e.g., 1/9, 2/9, ..., 9/9)
- ✅ Confirm final boss fight is at stage 9/9 instead of 5/9
- ✅ Verify LIFE power-ups don't drop from regular enemies in easy mode (TRIPLE, SHIELD, BOMB still drop)
- ✅ Boss fight in easy mode should feel appropriately challenging

🤖 Generated with [Claude Code](https://claude.com/claude-code)