### PR TITLE
feat(moonpatrol): Moon Patrol // Recon — new standalone arcade game

### DIFF
--- a/docs/superpowers/plans/2026-05-11-moonpatrol-recon.md
+++ b/docs/superpowers/plans/2026-05-11-moonpatrol-recon.md
@@ -1,0 +1,2093 @@
+# Moon Patrol // Recon — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a retro CRT arcade Moon Patrol-inspired horizontal side-scroller in `moonpatrol/` — moon buggy, dual cannons, 4 planets each with unique env mechanics and a boss fight.
+
+**Architecture:** Single HTML5 Canvas file (`moonpatrol/game.js`, ~700 lines) with a state machine, delta-time game loop, and a planet config array that drives terrain generation, enemy spawning, and environmental mechanics. No external libraries.
+
+**Tech Stack:** HTML5 Canvas 2D API, Web Audio API, vanilla ES6 IIFE, localStorage for hi-score.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-moonpatrol-recon-design.md`
+
+---
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `moonpatrol/index.html` | Canvas shell, CRT scanline/vignette CSS, loads `game.js` |
+| `moonpatrol/game.js` | Entire game: constants, state machine, loop, all subsystems |
+| `moonpatrol/images/` | Sprite PNGs (downloaded in Task 18) |
+| `moonpatrol/sounds/` | Audio files (downloaded in Task 17) |
+
+All tasks write to these four targets. The `moonpatrol/` directory is self-contained and does not touch `alien/`.
+
+---
+
+## Core Data Structures (reference for all tasks)
+
+```js
+// Canvas
+const W = 960, H = 640;
+const GROUND_Y = H - 80;          // y of ground top = 560
+const BUGGY_W = 52, BUGGY_H = 28;
+
+// Buggy
+let buggy = {
+  x: 80, y: GROUND_Y - BUGGY_H,   // top-left corner
+  vx: 150,                          // px/s rightward
+  vy: 0,
+  onGround: true,
+  sliding: false, slideTimer: 0,    // Europa ice slide
+  shield: false,
+  rapidFire: false, rapidTimer: 0,
+  missiles: 0,
+  scoreMultiplier: 1, scoreMultTimer: 0,
+  fireTimer: 0,                     // cooldown between shots
+};
+
+// Bullet  { x, y, vx, vy, w, h, owner:'player'|'enemy' }
+// Enemy   { type, x, y, w, h, hp, vx, vy, onGround, fireTimer, phase, phaseTimer }
+// Obstacle{ type:'crater'|'rock'|'ravine'|'spire'|'ice_wall', x, w, h }
+// Powerup { type:'rapid_fire'|'shield'|'missile'|'score_x2', x, y, w:16, h:16, timer:300 }
+// Particle{ x, y, vx, vy, color, life, maxLife, r }
+// Boss    { type, x, y, w, h, hp, maxHp, phase, phaseTimer, attackTimer, vx, vy }
+
+// Planet index: 0=Moon 1=Mars 2=Europa 3=Void
+// Progress: 0.0→1.0 per planet (triggers boss at 1.0)
+```
+
+---
+
+## Task 1: Project Scaffold
+
+**Files:**
+- Create: `moonpatrol/index.html`
+- Create: `moonpatrol/game.js`
+
+- [ ] **Step 1: Create `moonpatrol/index.html`**
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>MOON PATROL // RECON</title>
+<style>
+  :root { --amber:#ff9a3c; --gold:#ffd866; --bg:#0a0500; }
+  *{ box-sizing:border-box; margin:0; padding:0; }
+  html,body{ width:100%;height:100%;overflow:hidden;
+    background:radial-gradient(ellipse at 50% 30%,#150900 0%,#0a0500 70%);
+    color:var(--amber);
+    font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace; cursor:default; }
+  #stage{ position:fixed;inset:0;display:grid;place-items:center; }
+  #game{ image-rendering:pixelated;image-rendering:-moz-crisp-edges;
+    image-rendering:crisp-edges;background:#000;
+    box-shadow:0 0 60px rgba(255,154,60,0.18),0 0 120px rgba(192,64,32,0.10);
+    border:1px solid rgba(255,154,60,0.25);max-width:100vw;max-height:100vh; }
+  #stage::after{ content:"";position:fixed;inset:0;pointer-events:none;
+    background:
+      repeating-linear-gradient(to bottom,rgba(0,0,0,0) 0px,rgba(0,0,0,0) 2px,
+        rgba(0,0,0,0.22) 3px,rgba(0,0,0,0) 4px),
+      radial-gradient(ellipse at center,rgba(0,0,0,0) 55%,rgba(0,0,0,0.55) 100%);
+    mix-blend-mode:multiply;z-index:5; }
+</style>
+</head>
+<body>
+  <div id="stage">
+    <canvas id="game" width="960" height="640"></canvas>
+  </div>
+  <script src="game.js"></script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Create `moonpatrol/game.js` skeleton — canvas setup + empty loop**
+
+```js
+(() => {
+'use strict';
+
+const W = 960, H = 640;
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+let lastTs = 0;
+function loop(ts) {
+  const dt = Math.min((ts - lastTs) / 1000, 0.05);
+  lastTs = ts;
+  ctx.clearRect(0, 0, W, H);
+  ctx.fillStyle = '#0a0500';
+  ctx.fillRect(0, 0, W, H);
+  // placeholder: white dot so we know the loop runs
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(W/2, H/2, 4, 4);
+  requestAnimationFrame(loop);
+}
+requestAnimationFrame(loop);
+})();
+```
+
+- [ ] **Step 3: Verify scaffold**
+
+Open `moonpatrol/index.html` in a browser (or `python3 -m http.server 8080` from repo root, then visit `http://localhost:8080/moonpatrol/`).
+Expected: dark amber-tinted page, black canvas with a single white dot in the centre, CRT scanlines visible over the canvas.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moonpatrol/index.html moonpatrol/game.js
+git commit -m "feat(moonpatrol): scaffold canvas + CRT shell"
+```
+
+---
+
+## Task 2: Constants, State Machine & Planet Configs
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Replace `game.js` with constants + state machine + planet config block**
+
+```js
+(() => {
+'use strict';
+
+// ── canvas ──────────────────────────────────────────────────────────────────
+const W = 960, H = 640;
+const GROUND_Y = H - 80;   // y of ground top (560)
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+// ── state ────────────────────────────────────────────────────────────────────
+const S = { LOADING:'LOADING', TITLE:'TITLE', PLANET_INTRO:'PLANET_INTRO',
+            PLAYING:'PLAYING', BOSS:'BOSS', DYING:'DYING',
+            PLANET_CLEAR:'PLANET_CLEAR', GAME_OVER:'GAME_OVER', VICTORY:'VICTORY' };
+let state = S.TITLE;
+
+// ── scoring ──────────────────────────────────────────────────────────────────
+const PTS = { ufo_scout:150, moon_tank:100, sand_crawler:100, dive_bomber:150,
+              ice_drone:150, cryo_turret:200, phantom_drone:150, orbital_mine:120,
+              boss:2000, crater_clear:10, planet_nodeath:1000 };
+
+// ── planets ──────────────────────────────────────────────────────────────────
+const PLANETS = [
+  { id:'moon',   name:'MOON',   gravity:360, envId:'low_gravity',
+    palette:{ sky:'#0d1020', groundTop:'#3a3a50', groundFill:'#20202e',
+              star:'#c0c8d8', text:'#c8c8d0' },
+    enemies:['ufo_scout','moon_tank'],
+    obstacles:['crater','lunar_rock'],
+    patrolPx:8000, bossId:'lunar_fortress' },
+  { id:'mars',   name:'MARS',   gravity:560, envId:'dust_storm',
+    palette:{ sky:'#1e0800', groundTop:'#7a2a00', groundFill:'#3a1200',
+              star:'#c07040', text:'#e06030' },
+    enemies:['sand_crawler','dive_bomber'],
+    obstacles:['ravine','rock_spire'],
+    patrolPx:9000, bossId:'storm_titan' },
+  { id:'europa', name:'EUROPA', gravity:480, envId:'ice_slide',
+    palette:{ sky:'#050d1a', groundTop:'#5080b0', groundFill:'#102040',
+              star:'#a0d0ff', text:'#80c0ff' },
+    enemies:['ice_drone','cryo_turret'],
+    obstacles:['crevasse','ice_wall'],
+    patrolPx:9500, bossId:'glacial_sentinel' },
+  { id:'void',   name:'THE VOID', gravity:-40, envId:'zero_g',
+    palette:{ sky:'#0a0018', groundTop:'#4a1a6a', groundFill:'#1a0030',
+              star:'#b073ff', text:'#b073ff' },
+    enemies:['phantom_drone','orbital_mine'],
+    obstacles:['void_gap'],
+    patrolPx:10000, bossId:'the_overseer' },
+];
+
+// ── game variables (reset on new game) ────────────────────────────────────────
+let planetIdx, score, lives, hiScore, progress, scrollX, frame;
+let deathOnThisPlanet;
+
+hiScore = parseInt(localStorage.getItem('mpr_hi') || '0');
+
+// ── loop ─────────────────────────────────────────────────────────────────────
+let lastTs = 0;
+function loop(ts) {
+  const dt = Math.min((ts - lastTs) / 1000, 0.05);
+  lastTs = ts;
+  frame = (frame || 0) + 1;
+  update(dt);
+  draw();
+  requestAnimationFrame(loop);
+}
+
+function update(dt) { /* filled in later */ }
+function draw() {
+  ctx.fillStyle = PLANETS[planetIdx || 0].palette.sky;
+  ctx.fillRect(0, 0, W, H);
+}
+
+requestAnimationFrame(loop);
+})();
+```
+
+- [ ] **Step 2: Verify**
+
+Open the game. Expected: canvas fills with Moon's dark blue-grey sky (`#0d1020`). No errors in console.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): constants, state machine, planet configs"
+```
+
+---
+
+## Task 3: Buggy Physics
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Add buggy state + `initGame()` + physics update**
+
+Add after the planet configs, before the loop:
+
+```js
+// ── buggy ─────────────────────────────────────────────────────────────────────
+const BUGGY_W = 52, BUGGY_H = 28;
+let buggy;
+
+function initGame() {
+  planetIdx = 0; score = 0; lives = 3; progress = 0; scrollX = 0; frame = 0;
+  deathOnThisPlanet = false;
+  buggy = { x:80, y:GROUND_Y - BUGGY_H, vx:150, vy:0, onGround:true,
+            sliding:false, slideTimer:0, shield:false,
+            rapidFire:false, rapidTimer:0, missiles:0,
+            scoreMultiplier:1, scoreMultTimer:0, fireTimer:0 };
+  state = S.PLAYING;
+}
+
+function updateBuggy(dt) {
+  const pl = PLANETS[planetIdx];
+  const grav = pl.gravity;                     // px/s²
+
+  // gravity
+  if (!buggy.onGround) {
+    buggy.vy += grav * dt;
+  }
+
+  // zero-g upward drift
+  if (pl.envId === 'zero_g' && buggy.onGround) {
+    buggy.onGround = false;                    // no resting on ground in zero-g
+    buggy.vy = -80;                            // initial upward nudge
+  }
+
+  // downward thruster (Void only)
+  if (pl.envId === 'zero_g' && (keys['ArrowDown'] || keys['KeyS'])) {
+    buggy.vy += 600 * dt;
+  }
+
+  buggy.x += buggy.vx * dt;
+  buggy.y += buggy.vy * dt;
+
+  // ground collision
+  const groundTop = getGroundY(buggy.x + BUGGY_W / 2);
+  if (buggy.y + BUGGY_H >= groundTop) {
+    buggy.y = groundTop - BUGGY_H;
+    // Europa ice slide
+    if (pl.envId === 'ice_slide' && !buggy.onGround && Math.abs(buggy.vy) > 50) {
+      buggy.sliding = true; buggy.slideTimer = 0.8;
+    }
+    buggy.vy = 0;
+    buggy.onGround = true;
+  }
+
+  // ceiling
+  if (buggy.y < 32) { buggy.y = 32; buggy.vy = Math.max(0, buggy.vy); }
+
+  // ice slide decays
+  if (buggy.sliding) {
+    buggy.slideTimer -= dt;
+    if (buggy.slideTimer <= 0) buggy.sliding = false;
+  }
+
+  // power-up timers
+  if (buggy.rapidFire) { buggy.rapidTimer -= dt; if (buggy.rapidTimer <= 0) buggy.rapidFire = false; }
+  if (buggy.scoreMultiplier > 1) { buggy.scoreMultTimer -= dt; if (buggy.scoreMultTimer <= 0) buggy.scoreMultiplier = 1; }
+  buggy.fireTimer = Math.max(0, buggy.fireTimer - dt);
+}
+
+// placeholder — real terrain in Task 5
+function getGroundY(worldX) { return GROUND_Y; }
+```
+
+- [ ] **Step 2: Wire `update()` and add placeholder `drawBuggy()`**
+
+```js
+function update(dt) {
+  if (state !== S.PLAYING) return;
+  updateBuggy(dt);
+}
+
+function drawBuggy() {
+  const b = buggy;
+  ctx.fillStyle = '#ff9a3c';
+  ctx.fillRect(b.x - scrollX, b.y, BUGGY_W, BUGGY_H);
+  // wheels
+  ctx.fillStyle = '#ffd866';
+  ctx.beginPath(); ctx.arc(b.x - scrollX + 12, b.y + BUGGY_H, 8, 0, Math.PI*2); ctx.fill();
+  ctx.beginPath(); ctx.arc(b.x - scrollX + 40, b.y + BUGGY_H, 8, 0, Math.PI*2); ctx.fill();
+}
+```
+
+Add `drawBuggy()` call inside `draw()` when `state === S.PLAYING`.
+
+Also add `initGame()` call temporarily at the end of the file before `requestAnimationFrame(loop)`.
+
+- [ ] **Step 3: Verify**
+
+Open the game. Expected: amber rectangle (buggy) with two yellow circles (wheels) sits on the ground near the left edge. No falling through the floor.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): buggy physics — gravity, jump, ground collision"
+```
+
+---
+
+## Task 4: Input, Scrolling Terrain & Ground
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Add key state tracking**
+
+Add after constants:
+
+```js
+const keys = {};
+window.addEventListener('keydown', e => {
+  keys[e.code] = true;
+  if (['Space','ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.code)) e.preventDefault();
+  if (e.code === 'KeyP' && state === S.PLAYING) state = S.PAUSED;
+  else if (e.code === 'KeyP' && state === S.PAUSED) state = S.PLAYING;
+  if ((e.code === 'Space' || e.code === 'Enter') && state === S.TITLE) initGame();
+});
+window.addEventListener('keyup', e => { keys[e.code] = false; });
+```
+
+- [ ] **Step 2: Add input processing to `updateBuggy()`**
+
+Add at the TOP of `updateBuggy(dt)`, before gravity:
+
+```js
+// acceleration / brake
+const MIN_VX = 90, MAX_VX = 240;
+if (!buggy.sliding) {
+  if (keys['ArrowRight'] || keys['KeyD']) buggy.vx = Math.min(MAX_VX, buggy.vx + 240 * dt);
+  else if (keys['ArrowLeft'] || keys['KeyA']) buggy.vx = Math.max(MIN_VX, buggy.vx - 180 * dt);
+  else buggy.vx += (150 - buggy.vx) * 3 * dt;   // drift back to default speed
+}
+
+// jump
+if ((keys['ArrowUp'] || keys['KeyW'] || keys['Space']) && buggy.onGround && PLANETS[planetIdx].envId !== 'zero_g') {
+  buggy.vy = -420;
+  buggy.onGround = false;
+  // low gravity planets let you hold for extra lift
+  if (PLANETS[planetIdx].envId === 'low_gravity') buggy.vy = -380;
+}
+```
+
+- [ ] **Step 3: Add scrolling + terrain drawing**
+
+Add `scrollX` update to `update()`:
+
+```js
+function update(dt) {
+  if (state === S.PAUSED) return;
+  if (state !== S.PLAYING && state !== S.BOSS) return;
+  updateBuggy(dt);
+  if (state === S.PLAYING) {
+    scrollX += buggy.vx * dt;
+    progress = Math.min(1, scrollX / PLANETS[planetIdx].patrolPx);
+    if (progress >= 1) startBoss();
+  }
+}
+```
+
+Replace `draw()` with:
+
+```js
+function draw() {
+  const pl = PLANETS[planetIdx];
+  // sky
+  ctx.fillStyle = pl.palette.sky;
+  ctx.fillRect(0, 0, W, H);
+  drawStars(pl);
+  drawGround(pl);
+  drawBuggy();
+  if (state === S.PLAYING || state === S.BOSS) drawHUD();
+}
+
+function drawStars(pl) {
+  // two parallax star layers driven by scrollX
+  ctx.fillStyle = pl.palette.star;
+  const seed1 = 12345, seed2 = 67890;
+  for (let i = 0; i < 80; i++) {
+    const sx = ((seed1 * (i+1) * 7919) % 8000) - (scrollX * 0.15) % 8000;
+    const sy = ((seed1 * (i+1) * 3571) % (GROUND_Y - 60)) + 40;
+    ctx.fillRect(((sx % W) + W) % W, sy, 1 + (i%3 === 0 ? 1 : 0), 1 + (i%3 === 0 ? 1 : 0));
+  }
+  for (let i = 0; i < 40; i++) {
+    const sx = ((seed2 * (i+1) * 6271) % 8000) - (scrollX * 0.35) % 8000;
+    const sy = ((seed2 * (i+1) * 4127) % (GROUND_Y - 100)) + 60;
+    ctx.fillStyle = pl.palette.star;
+    ctx.globalAlpha = 0.5;
+    ctx.fillRect(((sx % W) + W) % W, sy, 2, 2);
+    ctx.globalAlpha = 1;
+  }
+}
+
+function drawGround(pl) {
+  // ground fill
+  ctx.fillStyle = pl.palette.groundFill;
+  ctx.fillRect(0, GROUND_Y, W, H - GROUND_Y);
+  // ground top strip (2px bright line)
+  ctx.fillStyle = pl.palette.groundTop;
+  ctx.fillRect(0, GROUND_Y, W, 4);
+}
+```
+
+- [ ] **Step 4: Stub `startBoss()` and `drawHUD()`**
+
+```js
+function startBoss() { state = S.BOSS; /* filled in Task 13 */ }
+function drawHUD() {
+  ctx.fillStyle = 'rgba(0,0,0,0.55)';
+  ctx.fillRect(0, 0, W, 32);
+  ctx.fillStyle = '#ffd866';
+  ctx.font = '13px monospace';
+  ctx.fillText('SCORE ' + String(score).padStart(7,'0'), 12, 21);
+  ctx.fillText(PLANETS[planetIdx].name, W/2 - 30, 21);
+  ctx.fillText('LIVES ' + '♥'.repeat(lives), W - 130, 21);
+}
+```
+
+- [ ] **Step 5: Verify**
+
+Expected: stars scroll at different speeds (parallax), amber ground at bottom, buggy drives right, score/lives HUD visible at top.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): input, scrolling terrain, parallax stars"
+```
+
+---
+
+## Task 5: Obstacle System
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Add obstacle generation**
+
+```js
+let obstacles = [];   // { type, x, w, h }
+
+function generateObstacles(pIdx) {
+  const pl = PLANETS[pIdx];
+  const result = [];
+  // deterministic placement based on planet index
+  let wx = 600;   // first obstacle not too close to spawn
+  const rng = mulberry32(pIdx * 9999 + 1);
+  while (wx < pl.patrolPx - 400) {
+    const gap = 300 + rng() * 400;
+    wx += gap;
+    const type = pl.obstacles[Math.floor(rng() * pl.obstacles.length)];
+    if (type === 'crater' || type === 'ravine' || type === 'crevasse' || type === 'void_gap') {
+      const w = type === 'ravine' ? 60 + rng() * 40 : 32 + rng() * 30;
+      result.push({ type, x: wx, w, h: 30 });
+    } else {
+      // solid obstacle (rock, spire, ice_wall)
+      result.push({ type, x: wx, w: 18, h: 28 + rng() * 20 | 0 });
+    }
+  }
+  return result;
+}
+
+function mulberry32(seed) {
+  return function() {
+    seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+    let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+    t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
+```
+
+- [ ] **Step 2: Update `getGroundY()` to return crater gap**
+
+```js
+function getGroundY(worldX) {
+  for (const o of obstacles) {
+    const isGap = o.type === 'crater' || o.type === 'ravine' ||
+                  o.type === 'crevasse' || o.type === 'void_gap';
+    if (isGap && worldX >= o.x && worldX <= o.x + o.w) {
+      return H + 100;   // below screen — buggy falls
+    }
+  }
+  return GROUND_Y;
+}
+```
+
+- [ ] **Step 3: Add rock/solid collision to `updateBuggy()`**
+
+Add after the ground collision block in `updateBuggy`:
+
+```js
+// solid obstacle collision (rocks, spires, ice walls)
+const screenX = buggy.x - scrollX;
+for (const o of obstacles) {
+  const isSolid = o.type === 'lunar_rock' || o.type === 'rock_spire' || o.type === 'ice_wall';
+  if (!isSolid) continue;
+  const ob = { x: o.x, y: GROUND_Y - o.h, w: o.w, h: o.h };
+  if (aabb({ x: buggy.x, y: buggy.y, w: BUGGY_W, h: BUGGY_H }, ob)) {
+    killBuggy();
+    return;
+  }
+}
+```
+
+- [ ] **Step 4: Add `aabb()`, `killBuggy()`, `drawObstacles()`**
+
+```js
+function aabb(a, b) {
+  return a.x < b.x + b.w && a.x + a.w > b.x &&
+         a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+function killBuggy() {
+  if (buggy.shield) { buggy.shield = false; return; }
+  lives--;
+  if (lives <= 0) { state = S.GAME_OVER; hiScore = Math.max(hiScore, score); localStorage.setItem('mpr_hi', hiScore); return; }
+  deathOnThisPlanet = true;
+  state = S.DYING;
+  setTimeout(() => { respawnBuggy(); state = S.PLAYING; }, 1200);
+}
+
+function respawnBuggy() {
+  buggy.x = 80; buggy.y = GROUND_Y - BUGGY_H; buggy.vx = 150; buggy.vy = 0;
+  buggy.onGround = true; buggy.shield = false; buggy.sliding = false;
+  buggy.rapidFire = false; buggy.missiles = 0; buggy.scoreMultiplier = 1;
+}
+
+function drawObstacles() {
+  for (const o of obstacles) {
+    const sx = o.x - scrollX;
+    if (sx > W + 50 || sx + o.w < -50) continue;
+    const pl = PLANETS[planetIdx];
+    if (o.type === 'crater' || o.type === 'ravine' || o.type === 'crevasse' || o.type === 'void_gap') {
+      // dark gap
+      ctx.fillStyle = '#000';
+      ctx.fillRect(sx, GROUND_Y, o.w, H - GROUND_Y);
+    } else {
+      // solid obstacle
+      ctx.fillStyle = pl.palette.groundTop;
+      ctx.fillRect(sx, GROUND_Y - o.h, o.w, o.h);
+      ctx.strokeStyle = pl.palette.star;
+      ctx.lineWidth = 1;
+      ctx.strokeRect(sx, GROUND_Y - o.h, o.w, o.h);
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Init obstacles in `initGame()` + add crater score**
+
+```js
+// in initGame():
+obstacles = generateObstacles(0);
+
+// in updateBuggy(), after ground collision when landing on real ground:
+if (buggy.onGround && getGroundY(buggy.x + BUGGY_W / 2) === GROUND_Y) {
+  // check if we just cleared a crater (crossed over it)
+  // simple: scored passively when progress ticks — handled in scoring section
+}
+```
+
+Add `drawObstacles()` call in `draw()` before `drawBuggy()`.
+
+- [ ] **Step 6: Verify**
+
+Expected: craters appear as black gaps in the ground; the buggy falls and dies when it drives into one (then respawns). Rock obstacles appear as bright rectangular pillars; hitting one kills the buggy.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): obstacle generation, crater gaps, solid collisions"
+```
+
+---
+
+## Task 6: Bullet System
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Add bullet arrays + fire logic**
+
+```js
+let bullets = [];   // { x, y, vx, vy, w, h, owner }
+
+function fireBuggy() {
+  const cooldown = buggy.rapidFire ? 0.1 : 0.25;
+  if (buggy.fireTimer > 0) return;
+  buggy.fireTimer = cooldown;
+  // forward bullet
+  bullets.push({ x: buggy.x + BUGGY_W, y: buggy.y + BUGGY_H * 0.4,
+                 vx: 700, vy: 0, w: 12, h: 4, owner: 'player' });
+  // upward bullet
+  bullets.push({ x: buggy.x + BUGGY_W * 0.6, y: buggy.y,
+                 vx: 0, vy: -650, w: 4, h: 12, owner: 'player' });
+}
+
+function fireMissile() {
+  if (buggy.missiles <= 0) return;
+  buggy.missiles--;
+  // homing missile — targets nearest aerial enemy; falls back to straight-up
+  const targets = enemies.filter(e => e.y < GROUND_Y - 40);
+  let tx = buggy.x + 200, ty = buggy.y - 200;
+  if (targets.length) {
+    const nearest = targets.reduce((a,b) => Math.hypot(a.x-buggy.x,a.y-buggy.y) < Math.hypot(b.x-buggy.x,b.y-buggy.y) ? a : b);
+    tx = nearest.x + nearest.w/2; ty = nearest.y + nearest.h/2;
+  }
+  const dx = tx - buggy.x, dy = ty - buggy.y;
+  const mag = Math.hypot(dx, dy) || 1;
+  bullets.push({ x: buggy.x + BUGGY_W * 0.6, y: buggy.y,
+                 vx: dx/mag * 600, vy: dy/mag * 600, w: 8, h: 8, owner: 'missile' });
+}
+
+function updateBullets(dt) {
+  for (const b of bullets) { b.x += b.vx * dt; b.y += b.vy * dt; }
+  // remove off-screen
+  for (let i = bullets.length - 1; i >= 0; i--) {
+    const b = bullets[i];
+    if (b.x > scrollX + W + 60 || b.x < scrollX - 60 || b.y < 0 || b.y > H) bullets.splice(i, 1);
+  }
+}
+
+function drawBullets() {
+  for (const b of bullets) {
+    ctx.fillStyle = b.owner === 'missile' ? '#ff2bd6' : b.owner === 'player' ? '#ffd866' : '#ff4040';
+    if (b.owner === 'missile') { ctx.fillStyle = '#ff2bd6'; ctx.fillRect(b.x - scrollX - b.w/2, b.y - b.h/2, b.w, b.h); }
+    else ctx.fillRect(b.x - scrollX, b.y, b.w, b.h);
+    // glow
+    ctx.shadowColor = ctx.fillStyle; ctx.shadowBlur = 6;
+    ctx.fillRect(b.x - scrollX, b.y, b.w, b.h);
+    ctx.shadowBlur = 0;
+  }
+}
+```
+
+- [ ] **Step 2: Wire fire input in `update()`**
+
+Add inside `update(dt)` in the `PLAYING` block:
+
+```js
+if ((keys['KeyZ'] || keys['ControlLeft'] || keys['ControlRight'])) fireBuggy();
+if (keys['KeyX']) fireMissile();
+```
+
+Add `updateBullets(dt)` call in `update()` and `drawBullets()` in `draw()`.
+
+- [ ] **Step 3: Verify**
+
+Expected: pressing Z fires a horizontal bullet to the right and a vertical bullet upward simultaneously. Bullets disappear when they leave the screen. Rapid fire power-up (manually set `buggy.rapidFire = true` in console) fires noticeably faster.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): bullet system — forward/upward/missile"
+```
+
+---
+
+## Task 7: Enemy System (Moon — Planet 0)
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Add enemy array + spawn + update**
+
+```js
+let enemies = [];
+let spawnTimer = 0;
+
+const ENEMY_CFG = {
+  ufo_scout:    { w:36, h:18, hp:1, spd:120, aerial:true,  fireRate:2.5 },
+  moon_tank:    { w:36, h:20, hp:2, spd:70,  aerial:false, fireRate:3.5 },
+  sand_crawler: { w:32, h:16, hp:1, spd:150, aerial:false, fireRate:0   },
+  dive_bomber:  { w:28, h:20, hp:1, spd:160, aerial:true,  fireRate:0, dives:true },
+  ice_drone:    { w:30, h:20, hp:1, spd:100, aerial:true,  fireRate:2.0 },
+  cryo_turret:  { w:24, h:28, hp:3, spd:0,   aerial:false, fireRate:2.8 },
+  phantom_drone:{ w:32, h:24, hp:2, spd:110, aerial:true,  fireRate:1.8, phases:true },
+  orbital_mine: { w:20, h:20, hp:1, spd:60,  aerial:true,  fireRate:0 },
+};
+
+function spawnEnemy(type, x, y) {
+  const cfg = ENEMY_CFG[type];
+  enemies.push({ type, x, y: y !== undefined ? y : (cfg.aerial ? 120 + Math.random()*180 : GROUND_Y - cfg.h),
+    w: cfg.w, h: cfg.h, hp: cfg.hp, maxHp: cfg.hp,
+    vx: -cfg.spd, vy: 0, fireTimer: Math.random() * cfg.fireRate,
+    phase: 0, phaseTimer: 0, visible: true });
+}
+
+function updateEnemies(dt) {
+  spawnTimer -= dt;
+  if (spawnTimer <= 0 && state === S.PLAYING) {
+    spawnTimer = 1.5 + Math.random() * 2;
+    const pl = PLANETS[planetIdx];
+    const type = pl.enemies[Math.floor(Math.random() * pl.enemies.length)];
+    spawnEnemy(type, scrollX + W + 60);
+  }
+
+  for (let i = enemies.length - 1; i >= 0; i--) {
+    const e = enemies[i];
+    // off-screen left → remove
+    if (e.x + e.w < scrollX - 60) { enemies.splice(i, 1); continue; }
+
+    e.x += e.vx * dt;
+
+    // ground stick for non-aerial
+    if (!ENEMY_CFG[e.type].aerial) {
+      e.y = GROUND_Y - e.h;
+    }
+
+    // UFO Scout: gentle sine wave
+    if (e.type === 'ufo_scout') {
+      e.phaseTimer += dt;
+      e.y += Math.sin(e.phaseTimer * 2) * 60 * dt;
+      e.y = Math.max(50, Math.min(GROUND_Y - 80, e.y));
+    }
+
+    // dive_bomber: arc downward then back up
+    if (e.type === 'dive_bomber') {
+      e.phaseTimer += dt;
+      if (e.phase === 0 && e.phaseTimer > 1.5) { e.phase = 1; e.phaseTimer = 0; e.vy = 300; }
+      if (e.phase === 1) { e.y += e.vy * dt; e.vy -= 600 * dt; if (e.vy < -200) { e.phase = 2; } }
+      if (e.phase === 2) { e.y += e.vy * dt; if (e.y < 60) { e.phase = 0; e.phaseTimer = 0; e.vy = 0; } }
+    }
+
+    // phantom_drone: blink in/out
+    if (e.type === 'phantom_drone') {
+      e.phaseTimer += dt;
+      e.visible = Math.floor(e.phaseTimer * 2) % 2 === 0;
+    }
+
+    // enemy fire
+    const cfg = ENEMY_CFG[e.type];
+    if (cfg.fireRate > 0) {
+      e.fireTimer -= dt;
+      if (e.fireTimer <= 0) {
+        e.fireTimer = cfg.fireRate + Math.random();
+        fireEnemy(e);
+      }
+    }
+
+    // cryo_turret: stationary on ground
+    if (e.type === 'cryo_turret') { e.vx = 0; }
+  }
+}
+
+function fireEnemy(e) {
+  const dx = buggy.x - e.x, dy = buggy.y - e.y;
+  const mag = Math.hypot(dx, dy) || 1;
+  if (e.type === 'cryo_turret') {
+    // 3-shot spread
+    for (let a = -0.3; a <= 0.3; a += 0.3) {
+      bullets.push({ x: e.x, y: e.y + e.h/2, vx: dx/mag*200 + Math.cos(a)*160, vy: dy/mag*200 + Math.sin(a)*160, w:6, h:6, owner:'enemy' });
+    }
+  } else {
+    bullets.push({ x: e.x, y: e.y + e.h/2, vx: dx/mag*200, vy: dy/mag*200, w:6, h:6, owner:'enemy' });
+  }
+}
+
+function drawEnemies() {
+  for (const e of enemies) {
+    if (!e.visible) continue;
+    const sx = e.x - scrollX;
+    if (sx > W + 50 || sx + e.w < -50) continue;
+    ctx.fillStyle = e.type.includes('ufo') || e.type.includes('drone') || e.type === 'orbital_mine' ? '#ff2bd6' : '#7dffae';
+    ctx.fillRect(sx, e.y, e.w, e.h);
+    // simple HP indicator (red bar above)
+    if (e.maxHp > 1) {
+      ctx.fillStyle = '#333'; ctx.fillRect(sx, e.y - 6, e.w, 4);
+      ctx.fillStyle = '#f44'; ctx.fillRect(sx, e.y - 6, e.w * (e.hp / e.maxHp), 4);
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Add collision checks in `update()`**
+
+```js
+function checkCollisions() {
+  const bRect = { x: buggy.x, y: buggy.y, w: BUGGY_W, h: BUGGY_H };
+
+  // player bullets vs enemies
+  for (let bi = bullets.length - 1; bi >= 0; bi--) {
+    const b = bullets[bi];
+    if (b.owner === 'enemy') continue;
+    const br = { x: b.x, y: b.y, w: b.w, h: b.h };
+    for (let ei = enemies.length - 1; ei >= 0; ei--) {
+      const e = enemies[ei];
+      if (!e.visible) continue;
+      if (aabb(br, { x: e.x, y: e.y, w: e.w, h: e.h })) {
+        e.hp--;
+        bullets.splice(bi, 1);
+        if (e.hp <= 0) {
+          addScore(PTS[e.type] || 100);
+          spawnPowerup(e.x, e.y);
+          spawnExplosion(e.x + e.w/2, e.y + e.h/2);
+          enemies.splice(ei, 1);
+        }
+        break;
+      }
+    }
+  }
+
+  // enemy bullets vs buggy
+  for (let bi = bullets.length - 1; bi >= 0; bi--) {
+    const b = bullets[bi];
+    if (b.owner !== 'enemy') continue;
+    if (aabb({ x: b.x, y: b.y, w: b.w, h: b.h }, bRect)) {
+      bullets.splice(bi, 1);
+      killBuggy();
+      return;
+    }
+  }
+
+  // enemies vs buggy (contact)
+  for (const e of enemies) {
+    if (!e.visible) continue;
+    if (aabb(bRect, { x: e.x, y: e.y, w: e.w, h: e.h })) { killBuggy(); return; }
+  }
+
+  // player bullets vs solid obstacles
+  for (let bi = bullets.length - 1; bi >= 0; bi--) {
+    const b = bullets[bi];
+    if (b.owner === 'enemy') continue;
+    for (let oi = obstacles.length - 1; oi >= 0; oi--) {
+      const o = obstacles[oi];
+      const isSolid = o.type === 'lunar_rock' || o.type === 'rock_spire' || o.type === 'ice_wall';
+      if (!isSolid) continue;
+      const or = { x: o.x, y: GROUND_Y - o.h, w: o.w, h: o.h };
+      if (aabb({ x: b.x, y: b.y, w: b.w, h: b.h }, or)) {
+        bullets.splice(bi, 1);
+        obstacles.splice(oi, 1);   // shootable obstacles are destroyed
+        spawnExplosion(o.x + o.w/2, GROUND_Y - o.h/2);
+        break;
+      }
+    }
+  }
+}
+
+function addScore(pts) {
+  score += pts * buggy.scoreMultiplier;
+  hiScore = Math.max(hiScore, score);
+}
+```
+
+Add `updateEnemies(dt)` and `checkCollisions()` to `update()`. Add `drawEnemies()` to `draw()`.
+
+Stub `spawnPowerup` and `spawnExplosion` for now:
+
+```js
+function spawnPowerup(x, y) { /* Task 12 */ }
+function spawnExplosion(x, y) { /* Task 11 */ }
+```
+
+- [ ] **Step 3: Verify**
+
+Expected: UFO Scouts and Moon Tanks spawn from the right, move left. Shooting them with Z removes them and increments score. Contact with them kills the buggy (uses a life). Shooting a lunar rock destroys it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): enemy system, collision detection, scoring"
+```
+
+---
+
+## Task 8: Environmental Mechanics
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Add `envState` object and `updateEnv()`**
+
+```js
+let envState = {};   // per-planet transient state
+
+function initEnv() {
+  envState = { dustTimer: 0, dustActive: false, dustAlpha: 0 };
+}
+
+function updateEnv(dt) {
+  const pl = PLANETS[planetIdx];
+  if (pl.envId === 'dust_storm') {
+    envState.dustTimer -= dt;
+    if (envState.dustTimer <= 0) {
+      if (envState.dustActive) {
+        // storm ending
+        envState.dustActive = false;
+        envState.dustTimer = 12 + Math.random() * 6;   // pause between storms
+        // restore enemy speeds
+        for (const e of enemies) e.vx = -ENEMY_CFG[e.type].spd;
+      } else {
+        // storm starting
+        envState.dustActive = true;
+        envState.dustTimer = 4;
+        // speed up enemies
+        for (const e of enemies) e.vx *= 1.4;
+      }
+    }
+    // fade dust alpha in/out
+    const target = envState.dustActive ? 0.70 : 0;
+    envState.dustAlpha += (target - envState.dustAlpha) * 5 * dt;
+  }
+
+  // zero-g: buggy drifts up (handled inside updateBuggy)
+  // low-g: handled via planet gravity value
+  // ice-slide: handled inside updateBuggy
+}
+
+function drawEnvOverlay() {
+  const pl = PLANETS[planetIdx];
+  if (pl.envId === 'dust_storm' && envState.dustAlpha > 0.01) {
+    ctx.fillStyle = `rgba(180,80,0,${envState.dustAlpha * 0.7})`;
+    ctx.fillRect(0, 0, W, H);
+    // dust particle streaks
+    ctx.fillStyle = `rgba(220,120,40,${envState.dustAlpha * 0.4})`;
+    for (let i = 0; i < 30; i++) {
+      const sx = ((i * 137 + frame * 3) % W);
+      const sy = 40 + (i * 73) % (GROUND_Y - 80);
+      ctx.fillRect(sx, sy, 40 + (i%4)*20, 2);
+    }
+  }
+}
+```
+
+Call `initEnv()` inside `initGame()` and `updateEnv(dt)` + `drawEnvOverlay()` in `update()` / `draw()`.
+
+- [ ] **Step 2: Verify each mechanic**
+
+- **Moon (low gravity)**: Jump — buggy should hang noticeably longer in the air than on Mars.
+- **Mars (dust storm)**: After ~12s the screen dims amber/orange and enemies speed up, then clears after 4s.
+- **Europa (ice slide)**: Land from a jump — buggy should slide forward 0.8s before stopping.
+- **Void (zero-g)**: Buggy drifts upward; `↓/S` applies downward thrust to stay on platforms.
+
+To test each planet quickly, temporarily set `planetIdx = N` in `initGame()` and reload.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): environmental mechanics — dust storm, low-g, ice slide, zero-g"
+```
+
+---
+
+## Task 9: Particles, Explosions & Power-ups
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Implement particle explosions**
+
+```js
+let particles = [];
+
+function spawnExplosion(x, y) {
+  const colors = ['#ffd866','#ff9a3c','#c04020','#ffffff'];
+  for (let i = 0; i < 14; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    const spd = 80 + Math.random() * 220;
+    particles.push({ x, y, vx: Math.cos(angle)*spd, vy: Math.sin(angle)*spd - 60,
+      color: colors[Math.floor(Math.random()*colors.length)],
+      life: 0.5 + Math.random()*0.4, maxLife: 0.9, r: 2 + Math.random()*3 });
+  }
+}
+
+function updateParticles(dt) {
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const p = particles[i];
+    p.x += p.vx * dt; p.y += p.vy * dt;
+    p.vy += 300 * dt;   // gravity on particles
+    p.life -= dt;
+    if (p.life <= 0) particles.splice(i, 1);
+  }
+}
+
+function drawParticles() {
+  for (const p of particles) {
+    ctx.globalAlpha = Math.max(0, p.life / p.maxLife);
+    ctx.fillStyle = p.color;
+    ctx.beginPath(); ctx.arc(p.x - scrollX, p.y, p.r, 0, Math.PI*2); ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+}
+```
+
+- [ ] **Step 2: Implement power-up drops + pickup**
+
+```js
+let powerups = [];
+
+function spawnPowerup(x, y) {
+  if (Math.random() > 0.20) return;   // 20% drop rate
+  const types = ['rapid_fire','shield','missile','score_x2'];
+  const type = types[Math.floor(Math.random() * types.length)];
+  powerups.push({ type, x, y: y - 10, w:16, h:16, timer: 5 });
+}
+
+const PU_COLORS = { rapid_fire:'#ffd866', shield:'#5ef0ff', missile:'#ff2bd6', score_x2:'#7dffae' };
+const PU_LABELS = { rapid_fire:'⚡', shield:'🛡', missile:'🚀', score_x2:'×2' };
+
+function updatePowerups(dt) {
+  for (let i = powerups.length - 1; i >= 0; i--) {
+    const p = powerups[i];
+    p.timer -= dt;
+    if (p.timer <= 0) { powerups.splice(i, 1); continue; }
+    // pickup collision
+    if (aabb({ x: buggy.x, y: buggy.y, w: BUGGY_W, h: BUGGY_H },
+             { x: p.x, y: p.y, w: p.w, h: p.h })) {
+      applyPowerup(p.type);
+      powerups.splice(i, 1);
+    }
+  }
+}
+
+function applyPowerup(type) {
+  if (type === 'rapid_fire') { buggy.rapidFire = true; buggy.rapidTimer = 8; }
+  else if (type === 'shield') { buggy.shield = true; }
+  else if (type === 'missile') { buggy.missiles = Math.min(buggy.missiles + 3, 9); }
+  else if (type === 'score_x2') { buggy.scoreMultiplier = 2; buggy.scoreMultTimer = 12; }
+}
+
+function drawPowerups() {
+  for (const p of powerups) {
+    const sx = p.x - scrollX;
+    if (sx < -30 || sx > W + 30) continue;
+    // blink when about to expire
+    if (p.timer < 1.5 && Math.floor(frame / 4) % 2 === 0) continue;
+    ctx.fillStyle = PU_COLORS[p.type];
+    ctx.fillRect(sx, p.y, p.w, p.h);
+    ctx.strokeStyle = '#fff'; ctx.lineWidth = 1; ctx.strokeRect(sx, p.y, p.w, p.h);
+    ctx.fillStyle = '#000'; ctx.font = '10px monospace';
+    ctx.fillText(PU_LABELS[p.type], sx + 2, p.y + 12);
+  }
+}
+```
+
+Add `updateParticles(dt)`, `updatePowerups(dt)` to `update()` and `drawParticles()`, `drawPowerups()` to `draw()`.
+
+- [ ] **Step 3: Verify**
+
+Kill an enemy — expect a particle burst. 20% of the time a coloured power-up box drops and floats. Drive over it and verify the corresponding buggy state changes (e.g., `buggy.shield = true`, `buggy.rapidFire = true`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): particle explosions and power-up drops"
+```
+
+---
+
+## Task 10: Full HUD
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Replace stub `drawHUD()` with full implementation**
+
+```js
+function drawHUD() {
+  const pl = PLANETS[planetIdx];
+  // top bar background
+  ctx.fillStyle = 'rgba(0,0,0,0.60)';
+  ctx.fillRect(0, 0, W, 44);
+
+  ctx.font = 'bold 13px monospace';
+
+  // score
+  ctx.fillStyle = '#ffd866';
+  ctx.fillText('SCORE ' + String(score).padStart(7,'0'), 12, 17);
+  // hi score
+  ctx.fillStyle = '#ff9a3c';
+  ctx.fillText('HI ' + String(hiScore).padStart(7,'0'), 12, 32);
+
+  // planet name (centre)
+  ctx.fillStyle = pl.palette.text;
+  ctx.textAlign = 'center';
+  ctx.fillText(pl.name, W/2, 17);
+  ctx.textAlign = 'left';
+
+  // lives (right)
+  ctx.fillStyle = '#ffd866';
+  const livesStr = '♥'.repeat(Math.max(0, lives));
+  ctx.fillText('LIVES ' + livesStr, W - 140, 17);
+
+  // active power-up indicators
+  let px = W - 140;
+  if (buggy.shield)       { ctx.fillStyle = '#5ef0ff'; ctx.fillText('SHLD', px, 32); px += 44; }
+  if (buggy.rapidFire)    { ctx.fillStyle = '#ffd866'; ctx.fillText('RPID', px, 32); px += 44; }
+  if (buggy.missiles > 0) { ctx.fillStyle = '#ff2bd6'; ctx.fillText('MSL×' + buggy.missiles, px, 32); }
+
+  // A→Z progress bar (below HUD)
+  const barX = 80, barY = 44, barW = W - 160, barH = 6;
+  ctx.fillStyle = '#1a0900';
+  ctx.fillRect(barX, barY, barW, barH);
+  ctx.fillStyle = pl.palette.groundTop;
+  ctx.fillRect(barX, barY, barW * progress, barH);
+  // sector labels A and Z
+  ctx.fillStyle = '#ff9a3c'; ctx.font = '10px monospace';
+  ctx.fillText('A', barX - 14, barY + 7);
+  ctx.fillText('Z', barX + barW + 4, barY + 7);
+  // BOSS marker
+  ctx.fillStyle = '#c04020';
+  ctx.fillText('BOSS▸', barX + barW - 36, barY - 2);
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Expected: top bar shows score, hi-score, planet name, lives hearts. Power-up labels appear when active. Progress bar fills left-to-right as you drive.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): full HUD — score, lives, progress bar, power-up indicators"
+```
+
+---
+
+## Task 11: Boss Framework + Lunar Fortress
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Add boss state + framework**
+
+```js
+let boss = null;
+
+const BOSS_CFG = {
+  lunar_fortress: { w:180, h:80, maxHp:30 },
+  storm_titan:    { w:160, h:120, maxHp:40 },
+  glacial_sentinel:{ w:100, h:160, maxHp:40 },
+  the_overseer:   { w:140, h:140, maxHp:60 },
+};
+
+function startBoss() {
+  const pl = PLANETS[planetIdx];
+  const cfg = BOSS_CFG[pl.bossId];
+  state = S.BOSS;
+  enemies = []; bullets = [];   // clear field
+  boss = { type: pl.bossId, x: scrollX + W + 40, y: GROUND_Y - cfg.h,
+           w: cfg.w, h: cfg.h, hp: cfg.maxHp, maxHp: cfg.maxHp,
+           phase: 0, phaseTimer: 0, attackTimer: 0, vx: -60, vy: 0 };
+}
+
+function updateBoss(dt) {
+  if (!boss) return;
+  boss.phaseTimer += dt;
+  boss.attackTimer -= dt;
+
+  switch (boss.type) {
+    case 'lunar_fortress':   updateLunarFortress(dt); break;
+    case 'storm_titan':      updateStormTitan(dt); break;
+    case 'glacial_sentinel': updateGlacialSentinel(dt); break;
+    case 'the_overseer':     updateOverseer(dt); break;
+  }
+
+  // player bullets vs boss
+  for (let bi = bullets.length - 1; bi >= 0; bi--) {
+    const b = bullets[bi];
+    if (b.owner === 'enemy') continue;
+    if (aabb({ x: b.x, y: b.y, w: b.w, h: b.h },
+             { x: boss.x, y: boss.y, w: boss.w, h: boss.h })) {
+      if (bossWeakPointHit(b)) {
+        boss.hp--;
+        bullets.splice(bi, 1);
+        spawnExplosion(b.x, b.y);
+        if (boss.hp <= 0) { defeatBoss(); return; }
+      } else {
+        bullets.splice(bi, 1);   // bullet absorbed but no damage
+      }
+    }
+  }
+  // buggy vs boss
+  if (aabb({ x: buggy.x, y: buggy.y, w: BUGGY_W, h: BUGGY_H },
+           { x: boss.x, y: boss.y, w: boss.w, h: boss.h })) killBuggy();
+}
+
+function bossWeakPointHit(bullet) {
+  if (!boss) return false;
+  // lunar_fortress: hatch open (phase 0 only, top-centre of boss)
+  if (boss.type === 'lunar_fortress') {
+    const hatchX = boss.x + boss.w*0.4, hatchW = boss.w*0.2;
+    return boss.phase === 0 && bullet.x >= hatchX && bullet.x <= hatchX + hatchW;
+  }
+  // storm_titan: engine pods (when hovering, phase 0 or 1)
+  if (boss.type === 'storm_titan') return boss.phase < 2;
+  // glacial_sentinel: chest (between attacks — phaseTimer > 1)
+  if (boss.type === 'glacial_sentinel') return boss.phaseTimer > 1;
+  // the_overseer: pupil always targetable but blocked by drone shield in phase 1
+  if (boss.type === 'the_overseer') return boss.phase !== 1 || enemies.length === 0;
+  return true;
+}
+
+function defeatBoss() {
+  addScore(PTS.boss);
+  if (!deathOnThisPlanet) addScore(PTS.planet_nodeath);
+  spawnExplosion(boss.x + boss.w/2, boss.y + boss.h/2);
+  for (let i = 0; i < 8; i++) setTimeout(() => spawnExplosion(boss.x + Math.random()*boss.w, boss.y + Math.random()*boss.h), i * 120);
+  boss = null;
+  if (planetIdx < PLANETS.length - 1) {
+    planetIdx++;
+    obstacles = generateObstacles(planetIdx);
+    enemies = []; bullets = []; powerups = [];
+    scrollX = 0; progress = 0; deathOnThisPlanet = false;
+    initEnv();
+    state = S.PLANET_CLEAR;
+    setTimeout(() => { state = S.PLAYING; }, 3000);
+  } else {
+    state = S.VICTORY;
+    hiScore = Math.max(hiScore, score);
+    localStorage.setItem('mpr_hi', hiScore);
+  }
+}
+
+function drawBoss() {
+  if (!boss) return;
+  const sx = boss.x - scrollX;
+  ctx.fillStyle = '#7a3a00';
+  ctx.fillRect(sx, boss.y, boss.w, boss.h);
+  ctx.strokeStyle = '#ff9a3c'; ctx.lineWidth = 2; ctx.strokeRect(sx, boss.y, boss.w, boss.h);
+  // HP bar
+  const bw = boss.w;
+  ctx.fillStyle = '#333'; ctx.fillRect(sx, boss.y - 14, bw, 8);
+  ctx.fillStyle = '#c04020'; ctx.fillRect(sx, boss.y - 14, bw * (boss.hp/boss.maxHp), 8);
+  ctx.strokeStyle = '#ffd866'; ctx.lineWidth = 1; ctx.strokeRect(sx, boss.y - 14, bw, 8);
+  ctx.fillStyle = '#ffd866'; ctx.font = '10px monospace';
+  ctx.fillText(boss.type.toUpperCase().replace('_',' '), sx, boss.y - 18);
+}
+```
+
+- [ ] **Step 2: Implement Lunar Fortress (3-phase boss)**
+
+```js
+function updateLunarFortress(dt) {
+  // Enter screen
+  if (boss.x > scrollX + W * 0.6) { boss.x += boss.vx * dt; return; }
+  boss.vx = 0;
+
+  if (boss.phase === 0) {
+    // Phase 0: open hatch and launch UFOs every 3s
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 3;
+      spawnEnemy('ufo_scout', boss.x + boss.w*0.4, boss.y);
+      spawnEnemy('ufo_scout', boss.x + boss.w*0.6, boss.y);
+    }
+    if (boss.hp <= boss.maxHp * 0.67) { boss.phase = 1; boss.phaseTimer = 0; boss.attackTimer = 2; }
+  }
+
+  if (boss.phase === 1) {
+    // Phase 1: drop arcing bombs
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 1.8;
+      // arc bomb — fires downward at buggy position
+      const dx = buggy.x - (boss.x + boss.w/2);
+      const dy = GROUND_Y - (boss.y + boss.h);
+      const t = 1.2;
+      bullets.push({ x: boss.x + boss.w/2, y: boss.y + boss.h,
+        vx: dx/t, vy: dy/t - 0.5 * 600 * t, w:10, h:10, owner:'enemy' });
+    }
+    if (boss.hp <= boss.maxHp * 0.33) { boss.phase = 2; boss.phaseTimer = 0; boss.vx = -180; boss.attackTimer = 0; }
+  }
+
+  if (boss.phase === 2) {
+    // Phase 3: charge forward
+    boss.x += boss.vx * dt;
+    if (boss.x < scrollX - 50) { boss.x = scrollX + W + 40; boss.vx = -180; }
+  }
+}
+```
+
+Add `updateBoss(dt)` and `drawBoss()` to `update()`/`draw()` (call when `state === S.BOSS`).
+
+- [ ] **Step 3: Verify Lunar Fortress**
+
+Drive to the end of Moon patrol (or temporarily set `progress = 0.99` in console). Expected: boss enters from right, stays at ~60% screen width. Phase 0: UFO scouts launch from hatch. Shooting the hatch centre damages the boss. Phase 2: boss charges and you must jump its chassis.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): boss framework + Lunar Fortress 3-phase fight"
+```
+
+---
+
+## Task 12: Storm Titan + Glacial Sentinel
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Implement Storm Titan (Mars boss)**
+
+```js
+function updateStormTitan(dt) {
+  // Hover above screen centre
+  const targetY = 80;
+  if (boss.phase < 2) boss.y += (targetY - boss.y) * 3 * dt;
+
+  if (boss.phase === 0) {
+    // fire 3-shot spread at buggy
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 2;
+      const cx = boss.x + boss.w/2;
+      for (let a = -0.25; a <= 0.25; a += 0.25) {
+        bullets.push({ x: cx, y: boss.y + boss.h, vx: Math.sin(a)*180, vy: 240, w:8, h:8, owner:'enemy' });
+      }
+    }
+    if (boss.hp <= boss.maxHp * 0.67) { boss.phase = 1; boss.phaseTimer = 0; boss.attackTimer = 1; }
+  }
+
+  if (boss.phase === 1) {
+    // dive at buggy then pull back up
+    if (boss.phaseTimer < 1.2) {
+      // descending
+      boss.y += 400 * dt;
+      if (boss.y + boss.h >= GROUND_Y) { boss.y = GROUND_Y - boss.h; boss.phaseTimer = 1.2; }
+    } else {
+      boss.y -= 300 * dt;
+      if (boss.y <= targetY) { boss.y = targetY; boss.phaseTimer = 0; boss.attackTimer = 1.5; }
+    }
+    if (boss.hp <= boss.maxHp * 0.33) { boss.phase = 2; boss.phaseTimer = 0; boss.attackTimer = 1; envState.dustActive = true; envState.dustAlpha = 0.7; }
+  }
+
+  if (boss.phase === 2) {
+    // dust storm active, spawn Dive Bombers as shields
+    boss.y += (targetY - boss.y) * 3 * dt;
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 3;
+      spawnEnemy('dive_bomber', boss.x + boss.w*0.3, boss.y + boss.h);
+      spawnEnemy('dive_bomber', boss.x + boss.w*0.6, boss.y + boss.h);
+    }
+    // fire rapidly
+    if (Math.floor(boss.phaseTimer * 3) % 1 === 0 && boss.attackTimer > 2.5) {
+      const cx = boss.x + boss.w/2;
+      bullets.push({ x: cx, y: boss.y + boss.h, vx: (Math.random()-0.5)*200, vy: 260, w:8, h:8, owner:'enemy' });
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Implement Glacial Sentinel (Europa boss)**
+
+```js
+function updateGlacialSentinel(dt) {
+  // Walk left toward buggy
+  const spd = boss.phase === 2 ? 90 : 60;
+  boss.x -= spd * dt;
+  if (boss.x < scrollX + 40) boss.x = scrollX + 40;   // stop at left edge
+
+  if (boss.phase === 0) {
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 2.8;
+      // ice shard spread — 3 shots at angles
+      for (let a = -0.4; a <= 0.4; a += 0.2) {
+        bullets.push({ x: boss.x, y: boss.y + boss.h*0.5,
+          vx: -180 + Math.cos(a)*120, vy: Math.sin(a)*180, w:8, h:8, owner:'enemy' });
+      }
+      // place an ice wall obstacle ahead of buggy
+      obstacles.push({ type:'ice_wall', x: scrollX + 400, w:18, h:40 });
+    }
+    if (boss.hp <= boss.maxHp * 0.67) { boss.phase = 1; boss.phaseTimer = 0; }
+  }
+
+  if (boss.phase === 1) {
+    // shockwave slam: animate downward fist then shockwave on ground
+    if (boss.phaseTimer < 0.6) { /* wind-up */ }
+    else if (boss.phaseTimer < 0.7) {
+      // spawn shockwave bullet at ground level travelling left
+      bullets.push({ x: boss.x - 20, y: GROUND_Y - 12, vx: -350, vy: 0, w:30, h:20, owner:'enemy' });
+      boss.phase = 0; boss.phaseTimer = 0;
+    }
+    if (boss.hp <= boss.maxHp * 0.33) { boss.phase = 2; }
+  }
+}
+```
+
+- [ ] **Step 3: Verify both bosses**
+
+Set `planetIdx = 1` and drive to end → Storm Titan should appear and hover. Shoot the engine pods (sides of the boss rect) to deal damage. Set `planetIdx = 2` and verify Glacial Sentinel walks left and spawns ice walls.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): Storm Titan + Glacial Sentinel bosses"
+```
+
+---
+
+## Task 13: The Overseer (Final Boss)
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Implement The Overseer with gravity reversal**
+
+```js
+let gravityReversed = false;
+let gravRevTimer = 0;
+
+function updateOverseer(dt) {
+  const cx = scrollX + W * 0.65;
+  const cy = H / 2;
+  // Float in centre
+  boss.x += (cx - boss.x - boss.w/2) * 2 * dt;
+  boss.y += (cy - boss.y - boss.h/2) * 2 * dt;
+
+  // gravity reversal countdown
+  if (gravityReversed) {
+    gravRevTimer -= dt;
+    if (gravRevTimer <= 0) {
+      gravityReversed = false;
+      buggy.vy = 0;
+    }
+  }
+
+  if (boss.phase === 0) {
+    // beam sweep: horizontal line that sweeps up → must jump over it
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 3.5;
+      // fire a wide slow beam that travels from right to left at ground+50
+      bullets.push({ x: scrollX + W, y: GROUND_Y - 50, vx: -300, vy: 0, w:W, h:14, owner:'enemy' });
+    }
+    if (boss.hp <= boss.maxHp * 0.75) { boss.phase = 1; boss.phaseTimer = 0; enemies = []; }
+  }
+
+  if (boss.phase === 1) {
+    // summon 4 phantom drones as shield ring
+    if (boss.phaseTimer < 0.1 && enemies.length === 0) {
+      for (let i = 0; i < 4; i++) spawnEnemy('phantom_drone', boss.x + Math.random()*boss.w, boss.y + Math.random()*boss.h);
+    }
+    if (boss.attackTimer <= 0) { boss.attackTimer = 4; fireEnemy(boss); }
+    if (enemies.length === 0) { boss.phase = 2; boss.phaseTimer = 0; boss.attackTimer = 5; }
+  }
+
+  if (boss.phase === 2) {
+    // gravity reversal every 5s
+    if (boss.attackTimer <= 0 && !gravityReversed) {
+      boss.attackTimer = 5;
+      gravityReversed = true;
+      gravRevTimer = 5;
+      buggy.vy = -300;   // fling upward (toward new "floor" which is the ceiling)
+    }
+    if (boss.hp <= boss.maxHp * 0.25) { boss.phase = 3; boss.phaseTimer = 0; boss.attackTimer = 0; }
+  }
+
+  if (boss.phase === 3) {
+    // rage: rapid random shots
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 0.4;
+      const angle = Math.random() * Math.PI * 2;
+      bullets.push({ x: boss.x + boss.w/2, y: boss.y + boss.h/2,
+        vx: Math.cos(angle) * 320, vy: Math.sin(angle) * 320, w:8, h:8, owner:'enemy' });
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Apply gravity reversal in `updateBuggy()`**
+
+In `updateBuggy`, change the gravity line to:
+
+```js
+const effectiveGrav = gravityReversed ? -pl.gravity : pl.gravity;
+if (!buggy.onGround) {
+  buggy.vy += effectiveGrav * dt;
+}
+```
+
+Add a ceiling-becomes-floor check when `gravityReversed`:
+
+```js
+if (gravityReversed && buggy.y <= 32 + BUGGY_H) {
+  buggy.y = 32 + BUGGY_H; buggy.vy = 0; buggy.onGround = true;
+}
+```
+
+Add a gravity-reversed visual indicator in `drawEnvOverlay()`:
+
+```js
+if (gravityReversed) {
+  ctx.fillStyle = 'rgba(176,115,255,0.15)';
+  ctx.fillRect(0, 0, W, H);
+  ctx.fillStyle = '#b073ff'; ctx.font = 'bold 14px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('⚠ GRAVITY REVERSED', W/2, H/2);
+  ctx.textAlign = 'left';
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Set `planetIdx = 3`, drive to end. Expected: The Overseer floats at screen centre. Phase 2 triggers gravity flip — buggy floats to ceiling and controls invert for 5 seconds. Phase 3 fires random shots from all angles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): The Overseer boss — 4 phases + gravity reversal"
+```
+
+---
+
+## Task 14: Game Screens & Hi-Score
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Title screen**
+
+```js
+function drawTitle() {
+  const pl = PLANETS[0];
+  ctx.fillStyle = pl.palette.sky; ctx.fillRect(0, 0, W, H);
+  drawStars(pl);
+  // title text
+  ctx.textAlign = 'center';
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 48px monospace';
+  ctx.fillText('MOON PATROL', W/2, 220);
+  ctx.fillStyle = '#ff9a3c'; ctx.font = 'bold 18px monospace';
+  ctx.fillText('// RECON', W/2, 256);
+  // blink
+  if (Math.floor(Date.now() / 600) % 2 === 0) {
+    ctx.fillStyle = '#c8c8d0'; ctx.font = '14px monospace';
+    ctx.fillText('PRESS SPACE OR ENTER TO START', W/2, 340);
+  }
+  ctx.fillStyle = '#ff9a3c'; ctx.font = '12px monospace';
+  ctx.fillText('HI-SCORE  ' + String(hiScore).padStart(7,'0'), W/2, 380);
+  ctx.fillStyle = '#7a4000'; ctx.font = '11px monospace';
+  ctx.fillText('← → DRIVE   ↑ JUMP   Z FIRE   X MISSILE   P PAUSE', W/2, 430);
+  ctx.textAlign = 'left';
+}
+```
+
+- [ ] **Step 2: Planet clear, game over, victory screens**
+
+```js
+let screenTimer = 0;
+
+function drawPlanetClear() {
+  ctx.fillStyle = 'rgba(0,0,0,0.75)'; ctx.fillRect(0, 0, W, H);
+  ctx.textAlign = 'center';
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 32px monospace';
+  ctx.fillText(PLANETS[planetIdx - 1]?.name + ' CLEARED!', W/2, H/2 - 40);
+  ctx.fillStyle = '#ff9a3c'; ctx.font = '16px monospace';
+  ctx.fillText('SCORE ' + String(score).padStart(7,'0'), W/2, H/2);
+  if (!deathOnThisPlanet) { ctx.fillStyle = '#7dffae'; ctx.fillText('NO DEATHS BONUS +1000', W/2, H/2 + 30); }
+  ctx.fillStyle = '#c8c8d0'; ctx.font = '13px monospace';
+  const nextName = PLANETS[planetIdx]?.name;
+  if (nextName) ctx.fillText('NEXT: ' + nextName, W/2, H/2 + 70);
+  ctx.textAlign = 'left';
+}
+
+function drawGameOver() {
+  ctx.fillStyle = 'rgba(0,0,0,0.80)'; ctx.fillRect(0, 0, W, H);
+  ctx.textAlign = 'center';
+  ctx.fillStyle = '#c04020'; ctx.font = 'bold 42px monospace';
+  ctx.fillText('GAME OVER', W/2, H/2 - 50);
+  ctx.fillStyle = '#ffd866'; ctx.font = '18px monospace';
+  ctx.fillText('SCORE ' + String(score).padStart(7,'0'), W/2, H/2);
+  if (score >= hiScore) { ctx.fillStyle = '#7dffae'; ctx.font = '14px monospace'; ctx.fillText('NEW HI-SCORE!', W/2, H/2 + 30); }
+  if (Math.floor(Date.now()/700) % 2 === 0) {
+    ctx.fillStyle = '#ff9a3c'; ctx.font = '13px monospace';
+    ctx.fillText('PRESS SPACE TO RETRY', W/2, H/2 + 70);
+  }
+  ctx.textAlign = 'left';
+}
+
+function drawVictory() {
+  ctx.fillStyle = 'rgba(0,0,0,0.75)'; ctx.fillRect(0, 0, W, H);
+  ctx.textAlign = 'center';
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 38px monospace';
+  ctx.fillText('MISSION COMPLETE', W/2, H/2 - 60);
+  ctx.fillStyle = '#7dffae'; ctx.font = '18px monospace';
+  ctx.fillText('ALL PLANETS CLEARED', W/2, H/2 - 20);
+  ctx.fillStyle = '#ffd866'; ctx.font = '16px monospace';
+  ctx.fillText('FINAL SCORE ' + String(score).padStart(7,'0'), W/2, H/2 + 20);
+  if (score >= hiScore) { ctx.fillStyle = '#ff2bd6'; ctx.font = '14px monospace'; ctx.fillText('★ NEW HI-SCORE ★', W/2, H/2 + 55); }
+  if (Math.floor(Date.now()/700) % 2 === 0) {
+    ctx.fillStyle = '#ff9a3c'; ctx.font = '13px monospace';
+    ctx.fillText('PRESS SPACE TO PLAY AGAIN', W/2, H/2 + 90);
+  }
+  ctx.textAlign = 'left';
+}
+```
+
+- [ ] **Step 3: Wire screens into `draw()` and add Space-to-restart**
+
+```js
+function draw() {
+  switch (state) {
+    case S.TITLE:         drawTitle(); break;
+    case S.GAME_OVER:     drawGameOver(); break;
+    case S.VICTORY:       drawVictory(); break;
+    case S.PLANET_CLEAR:  { const pl = PLANETS[planetIdx]; ctx.fillStyle=pl.palette.sky; ctx.fillRect(0,0,W,H); drawStars(pl); drawGround(pl); drawPlanetClear(); } break;
+    default: {
+      const pl = PLANETS[planetIdx];
+      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0, 0, W, H);
+      drawStars(pl); drawGround(pl); drawObstacles();
+      drawPowerups(); drawEnemies(); drawBullets(); drawBuggy();
+      drawParticles(); drawBoss(); drawEnvOverlay();
+      if (state !== S.DYING) drawHUD();
+    }
+  }
+}
+```
+
+Add Space/Enter key to restart from GAME_OVER and VICTORY in the keydown handler:
+
+```js
+if ((e.code === 'Space' || e.code === 'Enter') && (state === S.GAME_OVER || state === S.VICTORY)) initGame();
+```
+
+- [ ] **Step 4: Verify**
+
+Expected: Title screen shows on load with blinking text. SPACE starts the game. Clearing a planet shows the CLEARED screen for 3s before moving to the next planet. Dying all 3 lives shows GAME OVER with score. Victory shows on defeating The Overseer.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): game screens — title, planet clear, game over, victory"
+```
+
+---
+
+## Task 15: Planet Intro Screen
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Add `PLANET_INTRO` state between planet clear and playing**
+
+Update `defeatBoss()` to show planet intro before playing:
+
+```js
+// replace: state = S.PLAYING after setTimeout
+// with:
+state = S.PLANET_INTRO;
+let introTimer = 2.5;
+const introInterval = setInterval(() => {
+  introTimer -= 0.1;
+  if (introTimer <= 0) { clearInterval(introInterval); state = S.PLAYING; }
+}, 100);
+```
+
+- [ ] **Step 2: Draw planet intro**
+
+```js
+function drawPlanetIntro() {
+  const pl = PLANETS[planetIdx];
+  ctx.fillStyle = pl.palette.sky; ctx.fillRect(0, 0, W, H);
+  drawStars(pl);
+  ctx.textAlign = 'center';
+  ctx.fillStyle = pl.palette.text; ctx.font = 'bold 52px monospace';
+  ctx.fillText(pl.name, W/2, H/2 - 20);
+  ctx.fillStyle = '#ff9a3c'; ctx.font = '13px monospace';
+  const descs = ['PATROL ZONE ALPHA — LOW GRAVITY', 'DUST STORM WARNING IN EFFECT', 'ICY TERRAIN — TRACTION REDUCED', 'GRAVITY ANOMALY DETECTED'];
+  ctx.fillText(descs[planetIdx], W/2, H/2 + 30);
+  ctx.textAlign = 'left';
+}
+```
+
+Add `case S.PLANET_INTRO: drawPlanetIntro(); break;` to `draw()` switch. Add `updateBuggy` skip for `PLANET_INTRO` state.
+
+Also update `initGame()` to show planet intro for the first planet:
+
+```js
+// at the end of initGame(), replace state = S.PLAYING with:
+state = S.PLANET_INTRO;
+setTimeout(() => { state = S.PLAYING; }, 2500);
+```
+
+- [ ] **Step 3: Verify**
+
+Expected: Each planet transition shows a 2.5s interstitial with the planet name and a descriptor before gameplay begins.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): planet intro screens"
+```
+
+---
+
+## Task 16: Pause Screen
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Add pause overlay**
+
+```js
+function drawPaused() {
+  ctx.fillStyle = 'rgba(0,0,0,0.65)'; ctx.fillRect(0, 0, W, H);
+  ctx.textAlign = 'center';
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 28px monospace'; ctx.fillText('PAUSED', W/2, H/2 - 20);
+  ctx.fillStyle = '#ff9a3c'; ctx.font = '13px monospace'; ctx.fillText('PRESS P TO RESUME', W/2, H/2 + 20);
+  ctx.textAlign = 'left';
+}
+```
+
+Add `S.PAUSED` to the state enum. In `draw()` default case, add at the end:
+
+```js
+if (state === S.PAUSED) drawPaused();
+```
+
+- [ ] **Step 2: Verify P pauses and resumes, no game state changes while paused**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add moonpatrol/game.js
+git commit -m "feat(moonpatrol): pause screen"
+```
+
+---
+
+## Task 17: Audio
+
+**Files:**
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Add Web Audio `AudioMan` class**
+
+```js
+class AudioMan {
+  constructor() {
+    const C = window.AudioContext || window.webkitAudioContext;
+    this.ctx = C ? new C() : null;
+    if (!this.ctx) return;
+    this.master = this.ctx.createGain(); this.master.gain.value = 0.8;
+    this.master.connect(this.ctx.destination);
+    this.sfxG = this.ctx.createGain(); this.sfxG.gain.value = 0.7; this.sfxG.connect(this.master);
+    this.bufs = {};
+    this.engineNode = null; this.engineGain = null;
+  }
+
+  resume() { if (this.ctx?.state === 'suspended') this.ctx.resume(); }
+
+  async load(urls) {
+    if (!this.ctx) return;
+    await Promise.all(Object.entries(urls).map(async ([k, url]) => {
+      try {
+        const r = await fetch(url);
+        if (!r.ok) return;
+        const ab = await r.arrayBuffer();
+        this.bufs[k] = await this.ctx.decodeAudioData(ab);
+      } catch(e) { console.warn('audio load fail', url); }
+    }));
+  }
+
+  sfx(key, { rate=1, vol=0.6 } = {}) {
+    if (!this.ctx || !this.bufs[key]) return;
+    const s = this.ctx.createBufferSource(); s.buffer = this.bufs[key];
+    s.playbackRate.value = rate * (0.9 + Math.random()*0.2);
+    const g = this.ctx.createGain(); g.gain.value = vol;
+    s.connect(g).connect(this.sfxG); s.start(); s.onended = () => g.disconnect();
+  }
+
+  // Synthesised engine hum (no file needed)
+  startEngine() {
+    if (!this.ctx) return;
+    this.stopEngine();
+    const osc = this.ctx.createOscillator(); osc.type = 'sawtooth'; osc.frequency.value = 55;
+    const lfo = this.ctx.createOscillator(); lfo.frequency.value = 8;
+    const lfoGain = this.ctx.createGain(); lfoGain.gain.value = 6;
+    lfo.connect(lfoGain).connect(osc.frequency);
+    this.engineGain = this.ctx.createGain(); this.engineGain.gain.value = 0.08;
+    osc.connect(this.engineGain).connect(this.master);
+    osc.start(); lfo.start();
+    this.engineNode = osc; this._lfo = lfo; this._lfoGain = lfoGain;
+  }
+
+  stopEngine() {
+    try { this.engineNode?.stop(); this._lfo?.stop(); } catch(e) {}
+    this.engineNode = null;
+  }
+
+  setEngineSpeed(vx) {
+    if (!this.engineNode) return;
+    this.engineNode.frequency.value = 50 + vx * 0.18;
+  }
+}
+
+const audio = new AudioMan();
+```
+
+- [ ] **Step 2: Wire audio to game events**
+
+Add to `initGame()`:
+
+```js
+audio.resume();
+audio.startEngine();
+```
+
+Add to `fireBuggy()`:
+
+```js
+audio.sfx('cannon', { rate: 1.2, vol: 0.4 });
+```
+
+Add to `spawnExplosion()`:
+
+```js
+audio.sfx('boom', { rate: 0.8 + Math.random()*0.4, vol: 0.5 });
+```
+
+Add to `updateBuggy()` after vx update:
+
+```js
+audio.setEngineSpeed(buggy.vx);
+```
+
+Add to `defeatBoss()`:
+
+```js
+audio.sfx('boom', { rate: 0.5, vol: 0.9 });
+```
+
+- [ ] **Step 3: Create `moonpatrol/sounds/` download notes**
+
+Create `moonpatrol/sounds/README.md`:
+
+```
+# Sounds
+
+Download these free sounds and save with the filenames below:
+
+cannon.wav  — a short laser/zap sound
+            Source: freesound.org — search "laser zap" or "8-bit laser"
+            Suggestion: freesound.org/s/270343/ (8-bit laser, CC0)
+
+boom.wav    — explosion sound
+            Source: freesound.org — search "8-bit explosion"
+            Suggestion: freesound.org/s/387232/ (retro explosion, CC0)
+
+If no sounds are downloaded, the synthesised engine hum still works (no file needed).
+The game gracefully skips missing audio files.
+```
+
+- [ ] **Step 4: Verify**
+
+Start the game. Expected: a low engine hum plays immediately. Pressing Z produces a zap/laser sound. Enemy death produces an explosion sound. Engine pitch rises slightly when accelerating.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add moonpatrol/game.js moonpatrol/sounds/README.md
+git commit -m "feat(moonpatrol): Web Audio — synthesised engine + SFX hooks"
+```
+
+---
+
+## Task 18: Asset Integration
+
+**Files:**
+- Create: `moonpatrol/images/` (downloaded PNGs)
+- Create: `moonpatrol/images/README.md`
+- Modify: `moonpatrol/game.js`
+
+- [ ] **Step 1: Document asset sources**
+
+Create `moonpatrol/images/README.md`:
+
+```
+# Images
+
+All assets are free-use pixel art. Download and save with the filenames below.
+
+BUGGY
+  buggy.png (52×28) — pixel art moon buggy, side view facing right
+  Source: Kenney "Space Shooter Redux" pack — https://kenney.nl/assets/space-shooter-redux
+          or draw custom 52×28 in any pixel art editor
+
+UFO / AERIAL ENEMIES
+  ufo.png (36×18)        — flying saucer, top-down or side view
+  dive_bomber.png (28×20)
+  ice_drone.png (30×20)
+  phantom_drone.png (32×24)
+  orbital_mine.png (20×20) — spiky ball
+  Source: OpenGameArt "Space Shooter" by Kenney (CC0)
+          https://opengameart.org/content/space-shooter-redux
+
+GROUND ENEMIES
+  moon_tank.png (36×20)
+  sand_crawler.png (32×16)
+  cryo_turret.png (24×28)
+  Source: OpenGameArt "LPC: Space Enemies" or draw custom
+
+BOSSES (large sprites — can be assembled from shapes if no asset found)
+  boss_lunar_fortress.png (180×80)
+  boss_storm_titan.png (160×120)
+  boss_glacial_sentinel.png (100×160)
+  boss_overseer.png (140×140)
+
+EXPLOSION FRAMES
+  exp0.png through exp7.png (32×32 each)
+  Source: Kenney "Particle Pack" or OpenGameArt "explosion" search
+
+All assets should have transparent backgrounds (PNG-24 with alpha).
+If an asset has a white background, the keyWhite() function in game.js
+will strip it automatically.
+```
+
+- [ ] **Step 2: Add image loader with white-key to `game.js`**
+
+```js
+const IMGS = {};
+
+function keyWhite(img) {
+  const c = document.createElement('canvas');
+  c.width = img.width; c.height = img.height;
+  const gx = c.getContext('2d', { willReadFrequently: true });
+  gx.drawImage(img, 0, 0);
+  let id; try { id = gx.getImageData(0,0,c.width,c.height); } catch(e){ return img; }
+  const d = id.data;
+  if (d[3] < 250 || d[0] < 230) return img;
+  for (let i = 0; i < d.length; i += 4) {
+    const dist = 765 - d[i] - d[i+1] - d[i+2];
+    if (dist <= 8) { d[i+3] = 0; }
+    else if (dist <= 30) { d[i+3] = Math.floor(255 * (dist-8)/22); }
+  }
+  gx.putImageData(id, 0, 0); return c;
+}
+
+async function loadImg(src) {
+  return new Promise(res => {
+    const img = new Image();
+    img.onload = () => res(keyWhite(img));
+    img.onerror = () => res(null);
+    img.src = src;
+  });
+}
+
+async function loadAssets() {
+  const names = ['buggy','ufo','moon_tank','sand_crawler','dive_bomber',
+                 'ice_drone','cryo_turret','phantom_drone','orbital_mine',
+                 'boss_lunar_fortress','boss_storm_titan','boss_glacial_sentinel','boss_overseer'];
+  await Promise.all(names.map(async n => { IMGS[n] = await loadImg(`images/${n}.png`); }));
+  // explosion frames
+  IMGS.exp = [];
+  for (let i = 0; i < 8; i++) IMGS.exp.push(await loadImg(`images/exp${i}.png`));
+}
+```
+
+- [ ] **Step 3: Update draw functions to use sprites when available**
+
+In `drawBuggy()`, prepend:
+
+```js
+if (IMGS.buggy) { ctx.drawImage(IMGS.buggy, buggy.x - scrollX, buggy.y, BUGGY_W, BUGGY_H); return; }
+```
+
+In `drawEnemies()`, inside the loop:
+
+```js
+const imgKey = e.type.replace('_','');   // e.g. 'ufo_scout' → 'ufoscout'... adjust to match filename
+const img = IMGS[e.type] || IMGS[e.type.split('_')[0]];
+if (img && e.visible) { ctx.drawImage(img, sx, e.y, e.w, e.h); }
+else { /* existing placeholder rect drawing */ }
+```
+
+In `drawBoss()`, prepend:
+
+```js
+const bImg = IMGS['boss_' + boss.type.replace('_','_')];
+if (bImg) { ctx.drawImage(bImg, sx, boss.y, boss.w, boss.h); }
+else { /* existing rect */ }
+```
+
+Add animated explosion in `drawParticles()` — when an `IMGS.exp` frame array exists, replace circle drawing with a sprite frame based on remaining life ratio.
+
+- [ ] **Step 4: Wire `loadAssets()` at startup**
+
+Replace the final `requestAnimationFrame(loop)` with:
+
+```js
+loadAssets().then(() => requestAnimationFrame(loop));
+```
+
+- [ ] **Step 5: Verify with and without assets**
+
+Without any PNG files downloaded: game runs with coloured placeholder rectangles. With PNGs placed in `moonpatrol/images/`: sprites replace rectangles automatically.
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add moonpatrol/
+git commit -m "feat(moonpatrol): asset loader, sprite integration, image README"
+```
+
+---
+
+## Self-Review Notes
+
+Checked against spec `2026-05-11-moonpatrol-recon-design.md`:
+
+| Spec Requirement | Covered In |
+|---|---|
+| Moon Buggy vehicle, dual cannons | Task 3, 6 |
+| Forward + upward simultaneous fire | Task 6 |
+| Downward thruster (Void, `↓/S`) | Task 4 |
+| Missile (`X`) | Task 6 |
+| 4 planets with unique palettes | Task 2 |
+| Low gravity (Moon) | Task 3, 8 |
+| Dust storm (Mars) | Task 8 |
+| Ice slide (Europa) | Task 3, 8 |
+| Zero-G drift (Void) | Task 3, 8 |
+| All 8 enemy types | Task 7 |
+| Rapid fire, shield, missile, score×2 power-ups | Task 9 |
+| A→Z progress bar | Task 4, 10 |
+| Score, hi-score, lives HUD | Task 10 |
+| Lunar Fortress 3-phase boss | Task 11 |
+| Storm Titan 3-phase boss | Task 12 |
+| Glacial Sentinel 3-phase boss | Task 12 |
+| The Overseer 4-phase boss + gravity reversal | Task 13 |
+| Planet clear / game over / victory screens | Task 14 |
+| Planet intro screen | Task 15 |
+| Pause | Task 16 |
+| Web Audio engine hum + SFX | Task 17 |
+| Asset integration with white-key | Task 18 |
+| Hi-score localStorage | Task 14 |
+| No-death planet bonus | Task 14 |
+| Separate `moonpatrol/` directory | Task 1 |
+
+All spec requirements are covered.

--- a/docs/superpowers/specs/2026-05-11-moonpatrol-recon-design.md
+++ b/docs/superpowers/specs/2026-05-11-moonpatrol-recon-design.md
@@ -1,0 +1,179 @@
+# Moon Patrol // Recon — Design Spec
+*Date: 2026-05-11 · Approach B · Retro CRT Arcade · Planet Hopper*
+
+---
+
+## Overview
+
+A Moon Patrol-inspired horizontal side-scrolling arcade game, built as a completely separate HTML5 Canvas project alongside the existing Alien // Eclipse game. The player drives a moon buggy across four alien worlds, jumping craters and shooting enemies, culminating in a boss fight at the end of each planet. Retro CRT aesthetic: warm amber/green palette, chunky pixel art, scanline overlay.
+
+Lives: 3 per run, carried across planets. No continues.
+
+---
+
+## File Structure
+
+```
+moonpatrol/
+  index.html   — shell + CRT CSS, loads game.js
+  game.js      — single-file canvas engine (~700 lines)
+  images/      — free-use pixel art assets (downloaded)
+  sounds/      — engine rumble, cannon shot, explosion, boss music
+```
+
+The `moonpatrol/` directory sits alongside `/alien` in the repo root. It shares no code or assets with the alien game.
+
+---
+
+## Architecture
+
+Same single-file canvas pattern as `alien/game.js`:
+
+- **Constants block** — canvas size (960×640), colours, planet definitions, enemy/obstacle configs
+- **State machine** — `LOADING → TITLE → PLAYING → BOSS → DYING → GAME_OVER → VICTORY`
+- **Game loop** — 60 FPS `requestAnimationFrame`; input → update → draw
+- **Planet config objects** — each planet is a plain object (`{ palette, gravity, envMechanic, enemies, boss }`) that the loop reads; no subclassing
+- **Terrain generator** — deterministic per-planet: produces an array of `{ type, x, w }` obstacles (crater, rock, spire, etc.) with per-planet frequency/size parameters
+- **Entity lists** — `buggy`, `bullets[]`, `enemies[]`, `obstacles[]`, `powerups[]`, `particles[]`
+
+No external libraries. Web Audio API for sound, same pattern as the alien game.
+
+---
+
+## Canvas & HUD
+
+- Canvas: **960 × 640** px
+- Top HUD bar (32px): `SCORE 000000 · PLANET MOON I · LIVES ♥♥♥ · HI 000000`
+- Progress bar below HUD: A→Z fill with a `BOSS ▸` marker at the far right
+- Parallax background: two scroll layers (distant stars/sky, mid-ground terrain silhouette) at 0.2× and 0.6× buggy speed
+
+---
+
+## Controls
+
+| Input | Action |
+|---|---|
+| `← / A` | Brake (reduce speed; buggy always moves right, never reverses) |
+| `→ / D` | Accelerate (up to max speed) |
+| `↑ / W / Space` | Jump (hold longer = higher; one jump per airborne, no double-jump) |
+| `↓ / S` | Downward thruster *(Void only)* — counteracts zero-g upward drift |
+| `Z / Ctrl` | Fire — both cannons simultaneously: one bullet forward, one bullet straight up |
+| `X` | Fire missile *(only when Missile power-up is active)* |
+| `P` | Pause |
+
+The buggy never moves left. Forward bullets destroy ground enemies and shoot rocks; upward bullets destroy aerial enemies.
+
+---
+
+## The Four Planets
+
+### 1. Moon
+- **Palette**: grey-blue sky, cold white terrain, dark craters
+- **Terrain obstacles**: craters (jump only), lunar rocks (shoot or jump)
+- **Enemies**: UFO Scouts (fly in from right, strafe down), Moon Tanks (roll on ground, fire forward)
+- **Environmental mechanic**: **Low Gravity** — jump hang-time ×1.8, buggy floats noticeably longer
+- **Music/mood**: sparse, eerie, slow tempo
+
+### 2. Mars
+- **Palette**: dusty red sky, amber/sienna terrain, rock spires
+- **Terrain obstacles**: ravines (must jump — too wide to shoot), rock spires (shoot only — too tall to jump)
+- **Enemies**: Sand Crawlers (fast ground units, no shooting), Dive Bombers (swoop from above in arcs)
+- **Environmental mechanic**: **Dust Storm** — every ~15s, screen dims to 30% brightness for 4s; during storm all enemies gain +40% speed
+- **Music/mood**: tense, mid-tempo, percussion heavy
+
+### 3. Europa
+- **Palette**: icy cyan sky, deep blue-white terrain, crevasses
+- **Terrain obstacles**: crevasses (jump), ice walls (shoot — can't jump over, too tall)
+- **Enemies**: Ice Drones (hover, fire downward bursts), Cryo Turrets (stationary ground unit, fires ice shards in 3-shot spread)
+- **Environmental mechanic**: **Icy Surface** — on landing, buggy slides forward for 0.8s before stopping; player must anticipate braking before obstacles
+- **Music/mood**: cold, atmospheric, synth pads
+
+### 4. The Void *(unlocked after Europa)*
+- **Palette**: deep violet sky, neon pink asteroid platforms, star field
+- **Terrain obstacles**: gaps between floating asteroid platforms (fall = instant death)
+- **Enemies**: Phantom Drones (phase in/out of visibility), Orbital Mines (drift slowly across screen)
+- **Environmental mechanic**: **Zero-G** — buggy drifts upward at 8px/s passively; player must tap `↓ / S` (downward thruster) to counteract drift and stay on platforms
+- **Music/mood**: unsettling, arpeggiated, fast tempo for final stretch
+
+---
+
+## Bosses
+
+Each boss appears at the end of its planet's patrol zone (when progress bar reaches `Z`). During a boss fight the terrain stops scrolling; the boss occupies the right 40% of the screen.
+
+### Lunar Fortress *(Moon boss, 30 HP)*
+Giant armored crawler. Three phases:
+1. Opens hatch, launches 2 UFO Scouts; shoot the hatch for damage while dodging scouts
+2. Deploys roof cannon, fires arcing bombs at buggy position
+3. Charges forward; buggy must jump over its chassis
+
+**Weak point**: glowing hatch (top centre). Damage only dealt when hatch is open.
+
+### Storm Titan *(Mars boss, 40 HP)*
+Flying sand leviathan that hovers above the screen and swoops. Three phases:
+1. Fires 3-shot spread from belly; buggy shoots upward
+2. Dives at buggy — must drive under or jump the impact crater it creates
+3. Triggers full dust storm; spawns Dive Bombers as shields — kill them to reveal the Titan
+
+**Weak point**: two engine pods on the flanks (exposed only when hovering).
+
+### Glacial Sentinel *(Europa boss, 40 HP)*
+Slow-moving ice colossus that walks left toward the buggy. Three phases:
+1. Fires ice shards in arcs; shards create temporary ice wall obstacles on the ground
+2. Slams fist creating a shockwave — buggy must jump the wave
+3. Speeds up to 1.5× walk speed, attacks alternate rapidly
+
+**Weak point**: cracked chest panel (centre body). Only exposed between attacks.
+
+### The Overseer *(Void boss, 60 HP — final boss)*
+Massive floating eye. Four phases:
+1. Beam sweep attack across the ground; buggy must jump at the right moment
+2. Summons 4 Phantom Drones as a shield ring; destroy all to damage the eye
+3. **Gravity reversal** — screen flips upside-down for 5s; all controls invert
+4. **Rage mode** — fires rapid random projectiles; weak point exposed continuously
+
+**Weak point**: the pupil (centre of eye), always targetable but heavily shielded until phase 4.
+
+---
+
+## Power-Ups
+
+Dropped by enemies on death (20% chance). Disappear after 5 seconds if not collected.
+
+| Icon | Name | Effect | Duration |
+|---|---|---|---|
+| ⚡ | Rapid Fire | Double fire rate | 8s |
+| 🛡 | Shield | Absorbs 1 hit | Until hit |
+| 🚀 | Missile | 3 homing charges (fire with `X`) | 3 shots |
+| ✦ | Score ×2 | All kills worth double | 12s |
+
+---
+
+## Scoring
+
+| Event | Points |
+|---|---|
+| UFO / Drone destroyed | 150 |
+| Tank / Crawler destroyed | 100 |
+| Turret destroyed | 200 |
+| Boss defeated | 2 000 |
+| Crater cleared (jumped cleanly) | 10 |
+| Planet completed (no deaths) | 1 000 bonus |
+
+Hi-score persisted in `localStorage`.
+
+---
+
+## Asset Strategy
+
+All assets sourced from free-use pixel art libraries (OpenGameArt, itch.io free assets, Kenney.nl). Target art style: 16×16 to 32×32 sprites, limited palette per planet. Specific downloads resolved during implementation. Sounds: freesound.org (engine loop, cannon blast, explosion, boss alarm).
+
+---
+
+## Out of Scope
+
+- Multiplayer
+- Mobile/touch controls
+- Difficulty selection (one difficulty; challenge comes from planet progression)
+- Save/load (hi-score only via localStorage)
+- Procedural terrain (fixed per-planet obstacle arrays)

--- a/moonpatrol/README.md
+++ b/moonpatrol/README.md
@@ -1,0 +1,74 @@
+# MOON PATROL // RECON
+
+A retro CRT arcade horizontal side-scroller inspired by Moon Patrol (1982).  
+Drive a moon buggy across four alien worlds, shoot enemies, and defeat each planet's boss.
+
+## How to Play
+
+```
+python3 -m http.server 8080   # run from repo root
+# then open http://localhost:8080/moonpatrol/
+```
+
+## Controls
+
+| Input | Action |
+|---|---|
+| `← / A` | Brake |
+| `→ / D` | Accelerate |
+| `↑ / W / Space` | Jump (hold longer = higher) |
+| `↓ / S` | Downward thruster *(The Void only — fights zero-G drift)* |
+| `Z / Ctrl` | Fire — forward bullet + upward bullet simultaneously |
+| `X` | Launch homing missile *(collect the 🚀 power-up first)* |
+| `P` | Pause / Resume |
+
+The buggy always moves right. Speed varies; you cannot reverse.
+
+## Gameplay
+
+- **3 lives** per run, carried across all planets
+- Reach the end of each patrol zone (progress bar A→Z) to trigger the boss
+- Defeat the boss to unlock the next planet
+- Hi-score saved in your browser
+
+## The Four Planets
+
+| Planet | Environmental Mechanic | Boss |
+|---|---|---|
+| **Moon** | Low gravity — longer hang-time on jumps | Lunar Fortress (30 HP) |
+| **Mars** | Dust storm every ~15s — screen dims, enemies speed up | Storm Titan (40 HP) |
+| **Europa** | Icy surface — buggy slides on landing | Glacial Sentinel (40 HP) |
+| **The Void** | Zero-G — buggy drifts upward, use ↓ to stay on platforms | The Overseer (60 HP) |
+
+## Terrain
+
+| Obstacle | How to clear |
+|---|---|
+| Crater / Crevasse / Gap | Jump over |
+| Rock / Spire / Ice Wall | Shoot to destroy |
+| Void platform gaps | Jump (zero-G drift — keep thruster ready) |
+
+## Power-Ups
+
+Dropped by enemies on death (20% chance). Disappear after 5 seconds.
+
+| Icon | Power-Up | Effect |
+|---|---|---|
+| ⚡ | Rapid Fire | Double fire rate for 8s |
+| 🛡 | Shield | Absorbs 1 hit |
+| 🚀 | Missile | 3 homing shots (fire with `X`) |
+| ✦ | Score ×2 | All kills worth double for 12s |
+
+## Scoring
+
+| Event | Points |
+|---|---|
+| UFO / Drone | 150 |
+| Tank / Crawler | 100 |
+| Turret | 200 |
+| Boss defeated | 2 000 |
+| Planet cleared with no deaths | +1 000 bonus |
+
+## Assets
+
+Sprites and sounds are not included. See `images/README.md` and `sounds/README.md` for free-use download instructions. The game runs fully without any downloaded assets (rectangle fallback rendering + synthesized engine hum).

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -20,15 +20,15 @@ const PTS = { ufo_scout:150, moon_tank:100, sand_crawler:100, dive_bomber:150,
 
 // ── planets ──────────────────────────────────────────────────────────────────
 const PLANETS = [
-  { id:'moon',   name:'MOON',   gravity:360, envId:'low_gravity',
+  { id:'moon',   name:'MOON',   gravity:520, envId:'low_gravity',
     palette:{ sky:'#0d1020', groundTop:'#3a3a50', groundFill:'#20202e', star:'#c0c8d8', text:'#c8c8d0' },
     enemies:['ufo_scout','moon_tank'], obstacles:['crater','lunar_rock'],
     patrolPx:8000, bossId:'lunar_fortress' },
-  { id:'mars',   name:'MARS',   gravity:560, envId:'dust_storm',
+  { id:'mars',   name:'MARS',   gravity:900, envId:'dust_storm',
     palette:{ sky:'#1e0800', groundTop:'#7a2a00', groundFill:'#3a1200', star:'#c07040', text:'#e06030' },
     enemies:['sand_crawler','dive_bomber'], obstacles:['ravine','rock_spire'],
     patrolPx:9000, bossId:'storm_titan' },
-  { id:'europa', name:'EUROPA', gravity:480, envId:'ice_slide',
+  { id:'europa', name:'EUROPA', gravity:720, envId:'ice_slide',
     palette:{ sky:'#050d1a', groundTop:'#5080b0', groundFill:'#102040', star:'#a0d0ff', text:'#80c0ff' },
     enemies:['ice_drone','cryo_turret'], obstacles:['crevasse','ice_wall'],
     patrolPx:9500, bossId:'glacial_sentinel' },
@@ -185,14 +185,27 @@ hiScore = parseInt(localStorage.getItem('mpr_hi') || '0');
 
 // ── input ────────────────────────────────────────────────────────────────────
 const keys = {};
+const JUMP_KEYS = ['ArrowUp','KeyW','Space'];
 window.addEventListener('keydown', e => {
+  if (keys[e.code]) return;  // ignore key-repeat
   keys[e.code] = true;
   if (['Space','ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.code)) e.preventDefault();
   if (e.code === 'KeyP' && (state === S.PLAYING || state === S.BOSS)) paused = !paused;
   if ((e.code === 'Space' || e.code === 'Enter') && state === S.TITLE) initGame();
   if ((e.code === 'Space' || e.code === 'Enter') && (state === S.GAME_OVER || state === S.VICTORY)) initGame();
+  // variable jump — initiate on first press while on ground
+  if (JUMP_KEYS.includes(e.code) && (state === S.PLAYING || state === S.BOSS) &&
+      buggy && buggy.onGround && PLANETS[planetIdx].envId !== 'zero_g') {
+    buggy.vy = -210;
+    buggy.onGround = false;
+    buggy.jumping = true;
+    buggy.jumpTimer = 0;
+  }
 });
-window.addEventListener('keyup', e => { keys[e.code] = false; });
+window.addEventListener('keyup', e => {
+  keys[e.code] = false;
+  if (JUMP_KEYS.includes(e.code) && buggy) buggy.jumping = false;
+});
 
 // ── buggy ─────────────────────────────────────────────────────────────────────
 const BUGGY_W = 52, BUGGY_H = 28;
@@ -208,6 +221,7 @@ function initGame() {
   particles = []; powerups = [];
   boss = null;
   buggy = { x:80, y:GROUND_Y - BUGGY_H, vx:150, vy:0, onGround:true,
+            jumping:false, jumpTimer:0,
             sliding:false, slideTimer:0, shield:false,
             rapidFire:false, rapidTimer:0, missiles:0,
             scoreMultiplier:1, scoreMultTimer:0, fireTimer:0 };
@@ -243,13 +257,16 @@ function updateBuggy(dt) {
   }
   audio.setEngineSpeed(buggy.vx);
 
-  // jump
-  if ((keys['ArrowUp'] || keys['KeyW'] || keys['Space']) && buggy.onGround && pl.envId !== 'zero_g') {
-    buggy.vy = pl.envId === 'low_gravity' ? -380 : -420;
-    buggy.onGround = false;
+  // variable jump — hold key to boost upward for up to 0.28s
+  const jumpKeyHeld = keys['ArrowUp'] || keys['KeyW'] || keys['Space'];
+  if (buggy.jumping && jumpKeyHeld && buggy.vy < 0 && buggy.jumpTimer < 0.28) {
+    buggy.jumpTimer += dt;
+    buggy.vy -= 950 * dt;   // extra upward force while holding
+  } else if (!jumpKeyHeld) {
+    buggy.jumping = false;
   }
 
-  // apply gravity
+  // gravity
   const effectiveGrav = gravityReversed ? -pl.gravity : pl.gravity;
   if (!buggy.onGround) buggy.vy += effectiveGrav * dt;
 
@@ -265,6 +282,7 @@ function updateBuggy(dt) {
     }
     buggy.vy = 0;
     buggy.onGround = true;
+    buggy.jumping = false;
   }
 
   // ceiling collision for gravity reversal
@@ -370,7 +388,8 @@ function killBuggy() {
 
 function respawnBuggy() {
   buggy.x=scrollX+80; buggy.y=GROUND_Y-BUGGY_H; buggy.vx=150; buggy.vy=0;
-  buggy.onGround=true; buggy.shield=false; buggy.sliding=false;
+  buggy.onGround=true; buggy.jumping=false; buggy.jumpTimer=0;
+  buggy.shield=false; buggy.sliding=false;
   buggy.rapidFire=false; buggy.missiles=0; buggy.scoreMultiplier=1;
   buggy.fireTimer=0;
   gravityReversed = false;

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -125,7 +125,7 @@ function updateBuggy(dt) {
   }
 
   // ceiling
-  if (buggy.y < 44) { buggy.y = 44; buggy.vy = Math.max(0, buggy.vy); }
+  if (buggy.y < 32) { buggy.y = 32; buggy.vy = Math.max(0, buggy.vy); }
 
   // solid obstacle collision
   for (const o of obstacles) {
@@ -634,7 +634,8 @@ function startBoss() {
   state=S.BOSS; enemies=[]; bullets=[];
   boss={type:pl.bossId, x:scrollX+W+40, y:GROUND_Y-cfg.h,
         w:cfg.w, h:cfg.h, hp:cfg.maxHp, maxHp:cfg.maxHp,
-        phase:0, phaseTimer:0, attackTimer:0, vx:-60, vy:0};
+        phase:0, phaseTimer:0, attackTimer:0, vx:-60, vy:0,
+        hatchOpen:false, hatchTimer:0};
 }
 
 function updateBoss(dt) {
@@ -662,8 +663,7 @@ function updateBoss(dt) {
 function bossWeakPointHit(bullet) {
   if (!boss) return false;
   if (boss.type==='lunar_fortress') {
-    const hx=boss.x+boss.w*0.4, hw=boss.w*0.2;
-    return boss.phase===0 && bullet.x>=hx && bullet.x<=hx+hw;
+    return boss.phase===0 && boss.hatchOpen;
   }
   if (boss.type==='storm_titan') return boss.phase<2;
   if (boss.type==='glacial_sentinel') return boss.phaseTimer>1;
@@ -692,6 +692,14 @@ function drawBoss() {
   const sx=boss.x-scrollX;
   ctx.fillStyle='#7a3a00'; ctx.fillRect(sx,boss.y,boss.w,boss.h);
   ctx.strokeStyle='#ff9a3c'; ctx.lineWidth=2; ctx.strokeRect(sx,boss.y,boss.w,boss.h);
+  // lunar fortress hatch indicator
+  if (boss.type==='lunar_fortress' && boss.phase===0) {
+    const hatchX = sx + boss.w*0.35, hatchW = boss.w*0.3, hatchH = 14;
+    ctx.fillStyle = boss.hatchOpen ? '#ffd866' : '#5a4a00';
+    ctx.fillRect(hatchX, boss.y - hatchH, hatchW, hatchH);
+    ctx.strokeStyle = boss.hatchOpen ? '#fff' : '#888';
+    ctx.lineWidth = 1; ctx.strokeRect(hatchX, boss.y - hatchH, hatchW, hatchH);
+  }
   ctx.fillStyle='#333'; ctx.fillRect(sx,boss.y-14,boss.w,8);
   ctx.fillStyle='#c04020'; ctx.fillRect(sx,boss.y-14,boss.w*(boss.hp/boss.maxHp),8);
   ctx.strokeStyle='#ffd866'; ctx.lineWidth=1; ctx.strokeRect(sx,boss.y-14,boss.w,8);
@@ -703,6 +711,12 @@ function updateLunarFortress(dt) {
   if (boss.x > scrollX+W*0.6) { boss.x+=boss.vx*dt; return; }
   boss.vx=0;
   if (boss.phase===0) {
+    // hatch open/close cycle: 1s open, 1s closed
+    boss.hatchTimer += dt;
+    if (boss.hatchTimer >= 1.0) {
+      boss.hatchOpen = !boss.hatchOpen;
+      boss.hatchTimer = 0;
+    }
     if (boss.attackTimer<=0) {
       boss.attackTimer=3;
       spawnEnemy('ufo_scout',boss.x+boss.w*0.4,boss.y);
@@ -757,24 +771,41 @@ function updateStormTitan(dt) {
 }
 
 function updateGlacialSentinel(dt) {
-  const spd=boss.phase===2?90:60;
-  boss.x-=spd*dt;
-  if (boss.x<scrollX+40) boss.x=scrollX+40;
-  if (boss.phase===0) {
-    if (boss.attackTimer<=0) {
-      boss.attackTimer=2.8;
-      for (let a=-0.4;a<=0.4;a+=0.2)
-        bullets.push({x:boss.x,y:boss.y+boss.h*0.5,vx:-180+Math.cos(a)*120,vy:Math.sin(a)*180,w:8,h:8,owner:'enemy'});
-      obstacles.push({type:'ice_wall',x:scrollX+400,w:18,h:40});
+  // Phase escalation checked every frame
+  if (boss.hp <= boss.maxHp * 0.33 && boss.phase < 2) boss.phase = 2;
+  else if (boss.hp <= boss.maxHp * 0.67 && boss.phase < 1) { boss.phase = 1; boss.phaseTimer = 0; }
+
+  const spd = boss.phase === 2 ? 90 : 60;
+  boss.x -= spd * dt;
+  if (boss.x < scrollX + 40) boss.x = scrollX + 40;
+
+  if (boss.phase === 0) {
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 2.8;
+      for (let a = -0.4; a <= 0.4; a += 0.2)
+        bullets.push({x:boss.x, y:boss.y+boss.h*0.5, vx:-180+Math.cos(a)*120, vy:Math.sin(a)*180, w:8, h:8, owner:'enemy'});
+      obstacles.push({type:'ice_wall', x:scrollX+400, w:18, h:40});
     }
-    if (boss.hp<=boss.maxHp*0.67) { boss.phase=1; boss.phaseTimer=0; }
   }
-  if (boss.phase===1) {
-    if (boss.phaseTimer>=0.7) {
-      bullets.push({x:boss.x-20,y:GROUND_Y-12,vx:-350,vy:0,w:30,h:20,owner:'enemy'});
-      boss.phase=0; boss.phaseTimer=0;
+  if (boss.phase === 1) {
+    if (boss.phaseTimer >= 0.7) {
+      bullets.push({x:boss.x-20, y:GROUND_Y-12, vx:-350, vy:0, w:30, h:20, owner:'enemy'});
+      boss.phase = 0; boss.phaseTimer = 0;
     }
-    if (boss.hp<=boss.maxHp*0.33) boss.phase=2;
+  }
+  if (boss.phase === 2) {
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 1.8;
+      if (Math.random() < 0.35) {
+        // shockwave
+        bullets.push({x:boss.x-20, y:GROUND_Y-12, vx:-350, vy:0, w:30, h:20, owner:'enemy'});
+      } else {
+        // ice shards at 1.5× aggression
+        for (let a = -0.4; a <= 0.4; a += 0.2)
+          bullets.push({x:boss.x, y:boss.y+boss.h*0.5, vx:-180+Math.cos(a)*120, vy:Math.sin(a)*180, w:8, h:8, owner:'enemy'});
+        obstacles.push({type:'ice_wall', x:scrollX+400, w:18, h:40});
+      }
+    }
   }
 }
 
@@ -793,7 +824,7 @@ function drawPlanetClear() {
 
 function drawHUD() {
   const pl = PLANETS[planetIdx];
-  ctx.fillStyle='rgba(0,0,0,0.60)'; ctx.fillRect(0,0,W,44);
+  ctx.fillStyle='rgba(0,0,0,0.60)'; ctx.fillRect(0,0,W,32);
   ctx.font='bold 13px monospace';
   ctx.fillStyle='#ffd866'; ctx.fillText('SCORE '+String(score).padStart(7,'0'),12,17);
   ctx.fillStyle='#ff9a3c'; ctx.fillText('HI '+String(hiScore).padStart(7,'0'),12,32);
@@ -803,9 +834,12 @@ function drawHUD() {
   if (buggy.shield)       { ctx.fillStyle='#5ef0ff'; ctx.fillText('SHLD',px,32); px+=44; }
   if (buggy.rapidFire)    { ctx.fillStyle='#ffd866'; ctx.fillText('RPID',px,32); px+=44; }
   if (buggy.missiles>0)   { ctx.fillStyle='#ff2bd6'; ctx.fillText('MSL×'+buggy.missiles,px,32); }
-  const barX=80,barY=44,barW=W-160,barH=6;
+  const barX=80,barY=24,barW=W-160,barH=6;
   ctx.fillStyle='#1a0900'; ctx.fillRect(barX,barY,barW,barH);
   ctx.fillStyle=pl.palette.groundTop; ctx.fillRect(barX,barY,barW*progress,barH);
+  // progress cursor: 2px gold vertical line at current buggy position
+  const cursorX = barX + barW * progress;
+  ctx.fillStyle='#ffd866'; ctx.fillRect(cursorX - 1, barY - 2, 2, barH + 4);
   ctx.fillStyle='#ff9a3c'; ctx.font='10px monospace';
   ctx.fillText('A',barX-14,barY+7); ctx.fillText('Z',barX+barW+4,barY+7);
   ctx.fillStyle='#c04020'; ctx.fillText('BOSS▸',barX+barW-36,barY-2);

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -41,6 +41,7 @@ const PLANETS = [
 // ── game variables ────────────────────────────────────────────────────────────
 let planetIdx, score, lives, hiScore, progress, scrollX, frame;
 let deathOnThisPlanet;
+let gravityReversed = false, gravRevTimer = 0;
 hiScore = parseInt(localStorage.getItem('mpr_hi') || '0');
 
 // ── input ────────────────────────────────────────────────────────────────────
@@ -106,9 +107,8 @@ function updateBuggy(dt) {
   }
 
   // apply gravity
-  if (!buggy.onGround) {
-    buggy.vy += grav * dt;
-  }
+  const effectiveGrav = gravityReversed ? -pl.gravity : pl.gravity;
+  if (!buggy.onGround) buggy.vy += effectiveGrav * dt;
 
   buggy.x += buggy.vx * dt;
   buggy.y += buggy.vy * dt;
@@ -122,6 +122,11 @@ function updateBuggy(dt) {
     }
     buggy.vy = 0;
     buggy.onGround = true;
+  }
+
+  // ceiling collision for gravity reversal
+  if (gravityReversed && buggy.y <= 32 + BUGGY_H) {
+    buggy.y = 32 + BUGGY_H; buggy.vy = 0; buggy.onGround = true;
   }
 
   // ceiling
@@ -807,7 +812,55 @@ function updateGlacialSentinel(dt) {
   }
 }
 
-function updateOverseer(dt) {}
+function updateOverseer(dt) {
+  const cx = scrollX + W * 0.65;
+  const cy = H / 2;
+  boss.x += (cx - boss.x - boss.w/2) * 2 * dt;
+  boss.y += (cy - boss.y - boss.h/2) * 2 * dt;
+
+  if (gravityReversed) {
+    gravRevTimer -= dt;
+    if (gravRevTimer <= 0) {
+      gravityReversed = false;
+      buggy.vy = 0;
+    }
+  }
+
+  if (boss.phase === 0) {
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 3.5;
+      bullets.push({ x: scrollX + W, y: GROUND_Y - 50, vx: -300, vy: 0, w: W, h: 14, owner: 'enemy' });
+    }
+    if (boss.hp <= boss.maxHp * 0.75) { boss.phase = 1; boss.phaseTimer = 0; enemies = []; }
+  }
+
+  if (boss.phase === 1) {
+    if (boss.phaseTimer < 0.1 && enemies.length === 0) {
+      for (let i = 0; i < 4; i++) spawnEnemy('phantom_drone', boss.x + Math.random()*boss.w, boss.y + Math.random()*boss.h);
+    }
+    if (boss.attackTimer <= 0) { boss.attackTimer = 4; fireEnemy(boss); }
+    if (enemies.length === 0 && boss.phaseTimer > 0.5) { boss.phase = 2; boss.phaseTimer = 0; boss.attackTimer = 5; }
+  }
+
+  if (boss.phase === 2) {
+    if (boss.attackTimer <= 0 && !gravityReversed) {
+      boss.attackTimer = 5;
+      gravityReversed = true;
+      gravRevTimer = 5;
+      buggy.vy = -300;
+    }
+    if (boss.hp <= boss.maxHp * 0.25) { boss.phase = 3; boss.phaseTimer = 0; boss.attackTimer = 0; }
+  }
+
+  if (boss.phase === 3) {
+    if (boss.attackTimer <= 0) {
+      boss.attackTimer = 0.4;
+      const angle = Math.random() * Math.PI * 2;
+      bullets.push({ x: boss.x + boss.w/2, y: boss.y + boss.h/2,
+        vx: Math.cos(angle) * 320, vy: Math.sin(angle) * 320, w: 8, h: 8, owner: 'enemy' });
+    }
+  }
+}
 
 // ── planet clear overlay ──────────────────────────────────────────────────────
 function drawPlanetClear() {

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -410,10 +410,11 @@ function updateEnemies(dt) {
     const pl = PLANETS[planetIdx];
     spawnEnemy(pl.enemies[Math.floor(Math.random() * pl.enemies.length)], scrollX + W + 60);
   }
+  const speedMult = (PLANETS[planetIdx].envId === 'dust_storm' && envState.dustActive) ? 1.4 : 1.0;
   for (let i = enemies.length - 1; i >= 0; i--) {
     const e = enemies[i];
     if (e.x + e.w < scrollX - 60) { enemies.splice(i, 1); continue; }
-    e.x += e.vx * dt;
+    e.x += e.vx * speedMult * dt;
     if (!ENEMY_CFG[e.type].aerial) e.y = GROUND_Y - e.h;
     if (e.type === 'ufo_scout') {
       e.phaseTimer += dt;
@@ -524,11 +525,9 @@ function updateEnv(dt) {
       if (envState.dustActive) {
         envState.dustActive = false;
         envState.dustTimer = 12 + Math.random() * 6;
-        for (const e of enemies) e.vx = -ENEMY_CFG[e.type].spd;
       } else {
         envState.dustActive = true;
         envState.dustTimer = 4;
-        for (const e of enemies) e.vx *= 1.4;
       }
     }
     const target = envState.dustActive ? 0.70 : 0;
@@ -560,8 +559,9 @@ function spawnExplosion(x, y) {
   const colors = ['#ffd866','#ff9a3c','#c04020','#ffffff'];
   for (let i=0;i<14;i++) {
     const angle=Math.random()*Math.PI*2, spd=80+Math.random()*220;
+    const life = 0.5 + Math.random() * 0.4;
     particles.push({x,y,vx:Math.cos(angle)*spd,vy:Math.sin(angle)*spd-60,
-      color:colors[Math.floor(Math.random()*4)],life:0.5+Math.random()*0.4,maxLife:0.9,r:2+Math.random()*3});
+      color:colors[Math.floor(Math.random()*4)],life,maxLife:life,r:2+Math.random()*3});
   }
 }
 
@@ -662,11 +662,9 @@ function updateBoss(dt) {
 
 function bossWeakPointHit(bullet) {
   if (!boss) return false;
-  if (boss.type==='lunar_fortress') {
-    return boss.phase===0 && boss.hatchOpen;
-  }
+  if (boss.type==='lunar_fortress') return boss.hatchOpen;
   if (boss.type==='storm_titan') return boss.phase<2;
-  if (boss.type==='glacial_sentinel') return boss.phaseTimer>1;
+  if (boss.type==='glacial_sentinel') return true;
   if (boss.type==='the_overseer') return boss.phase!==1||enemies.length===0;
   return true;
 }
@@ -710,13 +708,13 @@ function drawBoss() {
 function updateLunarFortress(dt) {
   if (boss.x > scrollX+W*0.6) { boss.x+=boss.vx*dt; return; }
   boss.vx=0;
+  // hatch open/close cycle: 1s open, 1s closed — runs in all phases
+  boss.hatchTimer += dt;
+  if (boss.hatchTimer >= 1.0) {
+    boss.hatchOpen = !boss.hatchOpen;
+    boss.hatchTimer = 0;
+  }
   if (boss.phase===0) {
-    // hatch open/close cycle: 1s open, 1s closed
-    boss.hatchTimer += dt;
-    if (boss.hatchTimer >= 1.0) {
-      boss.hatchOpen = !boss.hatchOpen;
-      boss.hatchTimer = 0;
-    }
     if (boss.attackTimer<=0) {
       boss.attackTimer=3;
       spawnEnemy('ufo_scout',boss.x+boss.w*0.4,boss.y);

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -83,18 +83,7 @@ class AudioMan {
     s.onended = () => g.disconnect();
   }
 
-  startEngine() {
-    if (!this.ctx) return;
-    this.stopEngine();
-    const osc = this.ctx.createOscillator(); osc.type = 'sawtooth'; osc.frequency.value = 55;
-    const lfo = this.ctx.createOscillator(); lfo.frequency.value = 8;
-    const lfoGain = this.ctx.createGain(); lfoGain.gain.value = 6;
-    lfo.connect(lfoGain).connect(osc.frequency);
-    this.engineGain = this.ctx.createGain(); this.engineGain.gain.value = 0.08;
-    osc.connect(this.engineGain).connect(this.master);
-    osc.start(); lfo.start();
-    this.engineNode = osc; this._lfo = lfo;
-  }
+  startEngine() { /* engine hum disabled */ }
 
   stopEngine() {
     try { this.engineNode?.stop(); this._lfo?.stop(); } catch(e) {}

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -75,7 +75,7 @@ function initGame() {
   initEnv();
   state = S.PLANET_INTRO;
   Object.keys(keys).forEach(k => { keys[k] = false; });
-  setTimeout(() => { state = S.PLAYING; }, 2500);
+  setTimeout(() => { if (state === S.PLANET_INTRO) state = S.PLAYING; }, 2500);
 }
 
 function updateBuggy(dt) {

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -1,0 +1,21 @@
+(() => {
+'use strict';
+
+const W = 960, H = 640;
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+let lastTs = 0;
+function loop(ts) {
+  const dt = Math.min((ts - lastTs) / 1000, 0.05);
+  lastTs = ts;
+  ctx.clearRect(0, 0, W, H);
+  ctx.fillStyle = '#0a0500';
+  ctx.fillRect(0, 0, W, H);
+  // placeholder: white dot so we know the loop runs
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(W/2, H/2, 4, 4);
+  requestAnimationFrame(loop);
+}
+requestAnimationFrame(loop);
+})();

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -38,6 +38,70 @@ const PLANETS = [
     patrolPx:10000, bossId:'the_overseer' },
 ];
 
+// ── audio ─────────────────────────────────────────────────────────────────────
+class AudioMan {
+  constructor() {
+    const C = window.AudioContext || window.webkitAudioContext;
+    this.ctx = C ? new C() : null;
+    if (!this.ctx) return;
+    this.master = this.ctx.createGain(); this.master.gain.value = 0.8;
+    this.master.connect(this.ctx.destination);
+    this.sfxG = this.ctx.createGain(); this.sfxG.gain.value = 0.7;
+    this.sfxG.connect(this.master);
+    this.bufs = {};
+    this.engineNode = null; this.engineGain = null; this._lfo = null;
+  }
+
+  resume() { if (this.ctx?.state === 'suspended') this.ctx.resume(); }
+
+  async load(urls) {
+    if (!this.ctx) return;
+    await Promise.all(Object.entries(urls).map(async ([k, url]) => {
+      try {
+        const r = await fetch(url);
+        if (!r.ok) return;
+        const ab = await r.arrayBuffer();
+        this.bufs[k] = await this.ctx.decodeAudioData(ab);
+      } catch(e) { console.warn('audio load fail', url); }
+    }));
+  }
+
+  sfx(key, { rate = 1, vol = 0.6 } = {}) {
+    if (!this.ctx || !this.bufs[key]) return;
+    const s = this.ctx.createBufferSource(); s.buffer = this.bufs[key];
+    s.playbackRate.value = rate * (0.9 + Math.random() * 0.2);
+    const g = this.ctx.createGain(); g.gain.value = vol;
+    s.connect(g).connect(this.sfxG); s.start();
+    s.onended = () => g.disconnect();
+  }
+
+  startEngine() {
+    if (!this.ctx) return;
+    this.stopEngine();
+    const osc = this.ctx.createOscillator(); osc.type = 'sawtooth'; osc.frequency.value = 55;
+    const lfo = this.ctx.createOscillator(); lfo.frequency.value = 8;
+    const lfoGain = this.ctx.createGain(); lfoGain.gain.value = 6;
+    lfo.connect(lfoGain).connect(osc.frequency);
+    this.engineGain = this.ctx.createGain(); this.engineGain.gain.value = 0.08;
+    osc.connect(this.engineGain).connect(this.master);
+    osc.start(); lfo.start();
+    this.engineNode = osc; this._lfo = lfo;
+  }
+
+  stopEngine() {
+    try { this.engineNode?.stop(); this._lfo?.stop(); } catch(e) {}
+    this.engineNode = null; this._lfo = null;
+  }
+
+  setEngineSpeed(vx) {
+    if (!this.engineNode) return;
+    this.engineNode.frequency.value = 50 + vx * 0.18;
+  }
+}
+
+const audio = new AudioMan();
+audio.load({ cannon: 'sounds/cannon.wav', boom: 'sounds/boom.wav' });
+
 // ── game variables ────────────────────────────────────────────────────────────
 let planetIdx, score, lives, hiScore, progress, scrollX, frame;
 let deathOnThisPlanet;
@@ -63,6 +127,7 @@ let buggy;
 function initGame() {
   planetIdx = 0; score = 0; lives = 3; progress = 0; scrollX = 0; frame = 0;
   deathOnThisPlanet = false; paused = false;
+  audio.resume(); audio.startEngine();
   obstacles = generateObstacles(0);
   bullets = [];
   enemies = []; spawnTimer = 0;
@@ -99,6 +164,7 @@ function updateBuggy(dt) {
     else if (keys['ArrowLeft'] || keys['KeyA']) buggy.vx = Math.max(MIN_VX, buggy.vx - 180 * dt);
     else buggy.vx += (150 - buggy.vx) * 3 * dt;
   }
+  audio.setEngineSpeed(buggy.vx);
 
   // jump
   if ((keys['ArrowUp'] || keys['KeyW'] || keys['Space']) && buggy.onGround && pl.envId !== 'zero_g') {
@@ -249,7 +315,7 @@ function fireBuggy() {
   buggy.fireTimer = cooldown;
   bullets.push({ x:buggy.x+BUGGY_W, y:buggy.y+BUGGY_H*0.4, vx:700, vy:0, w:12, h:4, owner:'player' });
   bullets.push({ x:buggy.x+BUGGY_W*0.6, y:buggy.y, vx:0, vy:-650, w:4, h:12, owner:'player' });
-  if (typeof audio !== 'undefined') audio.sfx('cannon',{rate:1.2,vol:0.4});
+  audio.sfx('cannon', { rate: 1.2, vol: 0.4 });
 }
 
 function fireMissile() {
@@ -558,6 +624,7 @@ let particles = [];
 let powerups = [];
 
 function spawnExplosion(x, y) {
+  audio.sfx('boom', { rate: 0.8 + Math.random()*0.4, vol: 0.5 });
   const colors = ['#ffd866','#ff9a3c','#c04020','#ffffff'];
   for (let i=0;i<14;i++) {
     const angle=Math.random()*Math.PI*2, spd=80+Math.random()*220;
@@ -674,6 +741,7 @@ function bossWeakPointHit(bullet) {
 function defeatBoss() {
   addScore(PTS.boss);
   if (!deathOnThisPlanet) addScore(PTS.planet_nodeath);
+  audio.sfx('boom', { rate: 0.5, vol: 0.9 });
   const bx=boss.x, by=boss.y, bw=boss.w, bh=boss.h;
   for (let i=0;i<8;i++) setTimeout(()=>spawnExplosion(bx+Math.random()*bw,by+Math.random()*bh),i*120);
   boss=null;

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -193,18 +193,20 @@ window.addEventListener('keydown', e => {
   if (e.code === 'KeyP' && (state === S.PLAYING || state === S.BOSS)) paused = !paused;
   if ((e.code === 'Space' || e.code === 'Enter') && state === S.TITLE) initGame();
   if ((e.code === 'Space' || e.code === 'Enter') && (state === S.GAME_OVER || state === S.VICTORY)) initGame();
-  // variable jump — initiate on first press while on ground
+  // jump — full impulse on first press
   if (JUMP_KEYS.includes(e.code) && (state === S.PLAYING || state === S.BOSS) &&
       buggy && buggy.onGround && PLANETS[planetIdx].envId !== 'zero_g') {
-    buggy.vy = -210;
+    buggy.vy = -450;
     buggy.onGround = false;
     buggy.jumping = true;
-    buggy.jumpTimer = 0;
   }
 });
 window.addEventListener('keyup', e => {
   keys[e.code] = false;
-  if (JUMP_KEYS.includes(e.code) && buggy) buggy.jumping = false;
+  if (JUMP_KEYS.includes(e.code) && buggy) {
+    if (buggy.jumping && buggy.vy < 0) buggy.vy *= 0.35;  // cut jump short on early release
+    buggy.jumping = false;
+  }
 });
 
 // ── buggy ─────────────────────────────────────────────────────────────────────
@@ -249,7 +251,7 @@ function updateBuggy(dt) {
   }
 
   // acceleration / brake
-  const MIN_VX = 90, MAX_VX = 240;
+  const MIN_VX = 0, MAX_VX = 280;
   if (!buggy.sliding) {
     if (keys['ArrowRight'] || keys['KeyD']) buggy.vx = Math.min(MAX_VX, buggy.vx + 240 * dt);
     else if (keys['ArrowLeft'] || keys['KeyA']) buggy.vx = Math.max(MIN_VX, buggy.vx - 180 * dt);
@@ -257,14 +259,8 @@ function updateBuggy(dt) {
   }
   audio.setEngineSpeed(buggy.vx);
 
-  // variable jump — hold key to boost upward for up to 0.28s
-  const jumpKeyHeld = keys['ArrowUp'] || keys['KeyW'] || keys['Space'];
-  if (buggy.jumping && jumpKeyHeld && buggy.vy < 0 && buggy.jumpTimer < 0.28) {
-    buggy.jumpTimer += dt;
-    buggy.vy -= 950 * dt;   // extra upward force while holding
-  } else if (!jumpKeyHeld) {
-    buggy.jumping = false;
-  }
+  // clear jump state once ascending phase ends
+  if (buggy.jumping && buggy.vy >= 0) buggy.jumping = false;
 
   // gravity
   const effectiveGrav = gravityReversed ? -pl.gravity : pl.gravity;
@@ -382,8 +378,9 @@ function killBuggy() {
     state = S.GAME_OVER; hiScore = Math.max(hiScore,score); localStorage.setItem('mpr_hi',hiScore); return;
   }
   deathOnThisPlanet = true;
+  const wasBoss = (state === S.BOSS);
   state = S.DYING;
-  setTimeout(() => { respawnBuggy(); state = S.PLAYING; }, 1200);
+  setTimeout(() => { respawnBuggy(); state = wasBoss ? S.BOSS : S.PLAYING; }, 1200);
 }
 
 function respawnBuggy() {
@@ -479,7 +476,7 @@ function update(dt) {
   if (state === S.PLAYING) {
     scrollX += buggy.vx * dt;
     progress = Math.min(1, scrollX / PLANETS[planetIdx].patrolPx);
-    if (progress >= 1 && typeof startBoss === 'function') startBoss();
+    if (progress >= 1 && !boss && typeof startBoss === 'function') startBoss();
   }
   // fire input
   if (state===S.PLAYING||state===S.BOSS) {

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -69,6 +69,7 @@ function initGame() {
             rapidFire:false, rapidTimer:0, missiles:0,
             scoreMultiplier:1, scoreMultTimer:0, fireTimer:0 };
   state = S.PLANET_INTRO;
+  Object.keys(keys).forEach(k => { keys[k] = false; });
   setTimeout(() => { state = S.PLAYING; }, 2500);
 }
 
@@ -197,6 +198,7 @@ function aabb(a, b) {
 }
 
 function killBuggy() {
+  if (state === S.DYING || state === S.GAME_OVER) return;
   if (buggy.shield) { buggy.shield = false; return; }
   lives--;
   if (lives <= 0) {
@@ -208,9 +210,10 @@ function killBuggy() {
 }
 
 function respawnBuggy() {
-  buggy.x=80; buggy.y=GROUND_Y-BUGGY_H; buggy.vx=150; buggy.vy=0;
+  buggy.x=scrollX+80; buggy.y=GROUND_Y-BUGGY_H; buggy.vx=150; buggy.vy=0;
   buggy.onGround=true; buggy.shield=false; buggy.sliding=false;
   buggy.rapidFire=false; buggy.missiles=0; buggy.scoreMultiplier=1;
+  buggy.fireTimer=0;
 }
 
 function drawObstacles() {

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -64,10 +64,14 @@ function initGame() {
   deathOnThisPlanet = false;
   obstacles = generateObstacles(0);
   bullets = [];
+  enemies = []; spawnTimer = 0;
+  particles = []; powerups = [];
+  boss = null;
   buggy = { x:80, y:GROUND_Y - BUGGY_H, vx:150, vy:0, onGround:true,
             sliding:false, slideTimer:0, shield:false,
             rapidFire:false, rapidTimer:0, missiles:0,
             scoreMultiplier:1, scoreMultTimer:0, fireTimer:0 };
+  initEnv();
   state = S.PLANET_INTRO;
   Object.keys(keys).forEach(k => { keys[k] = false; });
   setTimeout(() => { state = S.PLAYING; }, 2500);
@@ -376,22 +380,432 @@ function drawGround(pl) {
   ctx.fillRect(0, GROUND_Y, W, 4);
 }
 
-function startBoss() { state = S.BOSS; }
+// ── enemies ───────────────────────────────────────────────────────────────────
+let enemies = [];
+let spawnTimer = 0;
+
+const ENEMY_CFG = {
+  ufo_scout:    { w:36, h:18, hp:1, spd:120, aerial:true,  fireRate:2.5 },
+  moon_tank:    { w:36, h:20, hp:2, spd:70,  aerial:false, fireRate:3.5 },
+  sand_crawler: { w:32, h:16, hp:1, spd:150, aerial:false, fireRate:0   },
+  dive_bomber:  { w:28, h:20, hp:1, spd:160, aerial:true,  fireRate:0   },
+  ice_drone:    { w:30, h:20, hp:1, spd:100, aerial:true,  fireRate:2.0 },
+  cryo_turret:  { w:24, h:28, hp:3, spd:0,   aerial:false, fireRate:2.8 },
+  phantom_drone:{ w:32, h:24, hp:2, spd:110, aerial:true,  fireRate:1.8 },
+  orbital_mine: { w:20, h:20, hp:1, spd:60,  aerial:true,  fireRate:0 },
+};
+
+function spawnEnemy(type, x, y) {
+  const cfg = ENEMY_CFG[type];
+  enemies.push({ type, x, y: y !== undefined ? y : (cfg.aerial ? 120 + Math.random()*180 : GROUND_Y - cfg.h),
+    w: cfg.w, h: cfg.h, hp: cfg.hp, maxHp: cfg.hp,
+    vx: -cfg.spd, vy: 0, fireTimer: Math.random() * (cfg.fireRate || 1),
+    phase: 0, phaseTimer: 0, visible: true });
+}
+
+function updateEnemies(dt) {
+  spawnTimer -= dt;
+  if (spawnTimer <= 0 && state === S.PLAYING) {
+    spawnTimer = 1.5 + Math.random() * 2;
+    const pl = PLANETS[planetIdx];
+    spawnEnemy(pl.enemies[Math.floor(Math.random() * pl.enemies.length)], scrollX + W + 60);
+  }
+  for (let i = enemies.length - 1; i >= 0; i--) {
+    const e = enemies[i];
+    if (e.x + e.w < scrollX - 60) { enemies.splice(i, 1); continue; }
+    e.x += e.vx * dt;
+    if (!ENEMY_CFG[e.type].aerial) e.y = GROUND_Y - e.h;
+    if (e.type === 'ufo_scout') {
+      e.phaseTimer += dt;
+      e.y += Math.sin(e.phaseTimer * 2) * 60 * dt;
+      e.y = Math.max(50, Math.min(GROUND_Y - 80, e.y));
+    }
+    if (e.type === 'dive_bomber') {
+      e.phaseTimer += dt;
+      if (e.phase === 0 && e.phaseTimer > 1.5) { e.phase = 1; e.phaseTimer = 0; e.vy = 300; }
+      if (e.phase === 1) { e.y += e.vy * dt; e.vy -= 600 * dt; if (e.vy < -200) e.phase = 2; }
+      if (e.phase === 2) { e.y += e.vy * dt; if (e.y < 60) { e.phase = 0; e.phaseTimer = 0; e.vy = 0; } }
+    }
+    if (e.type === 'phantom_drone') {
+      e.phaseTimer += dt;
+      e.visible = Math.floor(e.phaseTimer * 2) % 2 === 0;
+    }
+    if (e.type === 'cryo_turret') e.vx = 0;
+    const cfg = ENEMY_CFG[e.type];
+    if (cfg.fireRate > 0) {
+      e.fireTimer -= dt;
+      if (e.fireTimer <= 0) { e.fireTimer = cfg.fireRate + Math.random(); fireEnemy(e); }
+    }
+  }
+}
+
+function fireEnemy(e) {
+  const dx = buggy.x - e.x, dy = buggy.y - e.y, mag = Math.hypot(dx, dy) || 1;
+  if (e.type === 'cryo_turret') {
+    for (let a = -0.3; a <= 0.3; a += 0.3)
+      bullets.push({ x:e.x, y:e.y+e.h/2, vx:dx/mag*200+Math.cos(a)*160, vy:dy/mag*200+Math.sin(a)*160, w:6, h:6, owner:'enemy' });
+  } else {
+    bullets.push({ x:e.x, y:e.y+e.h/2, vx:dx/mag*200, vy:dy/mag*200, w:6, h:6, owner:'enemy' });
+  }
+}
+
+function drawEnemies() {
+  for (const e of enemies) {
+    if (!e.visible) continue;
+    const sx = e.x - scrollX;
+    if (sx > W+50 || sx+e.w < -50) continue;
+    ctx.fillStyle = (e.type.includes('ufo')||e.type.includes('drone')||e.type==='orbital_mine') ? '#ff2bd6' : '#7dffae';
+    ctx.fillRect(sx, e.y, e.w, e.h);
+    if (e.maxHp > 1) {
+      ctx.fillStyle='#333'; ctx.fillRect(sx,e.y-6,e.w,4);
+      ctx.fillStyle='#f44'; ctx.fillRect(sx,e.y-6,e.w*(e.hp/e.maxHp),4);
+    }
+  }
+}
+
+function checkCollisions() {
+  const bRect = { x:buggy.x, y:buggy.y, w:BUGGY_W, h:BUGGY_H };
+  // player bullets vs enemies
+  for (let bi=bullets.length-1; bi>=0; bi--) {
+    const b=bullets[bi];
+    if (b.owner==='enemy') continue;
+    for (let ei=enemies.length-1; ei>=0; ei--) {
+      const e=enemies[ei];
+      if (!e.visible) continue;
+      if (aabb({x:b.x,y:b.y,w:b.w,h:b.h},{x:e.x,y:e.y,w:e.w,h:e.h})) {
+        e.hp--; bullets.splice(bi,1);
+        if (e.hp<=0) { addScore(PTS[e.type]||100); spawnPowerup(e.x,e.y); spawnExplosion(e.x+e.w/2,e.y+e.h/2); enemies.splice(ei,1); }
+        break;
+      }
+    }
+  }
+  // enemy bullets vs buggy
+  for (let bi=bullets.length-1; bi>=0; bi--) {
+    const b=bullets[bi];
+    if (b.owner!=='enemy') continue;
+    if (aabb({x:b.x,y:b.y,w:b.w,h:b.h},bRect)) { bullets.splice(bi,1); killBuggy(); return; }
+  }
+  // enemies vs buggy contact
+  for (const e of enemies) {
+    if (!e.visible) continue;
+    if (aabb(bRect,{x:e.x,y:e.y,w:e.w,h:e.h})) { killBuggy(); return; }
+  }
+  // player bullets vs solid obstacles
+  for (let bi=bullets.length-1; bi>=0; bi--) {
+    const b=bullets[bi];
+    if (b.owner==='enemy') continue;
+    for (let oi=obstacles.length-1; oi>=0; oi--) {
+      const o=obstacles[oi];
+      if (o.type!=='lunar_rock'&&o.type!=='rock_spire'&&o.type!=='ice_wall') continue;
+      if (aabb({x:b.x,y:b.y,w:b.w,h:b.h},{x:o.x,y:GROUND_Y-o.h,w:o.w,h:o.h})) {
+        bullets.splice(bi,1); obstacles.splice(oi,1); spawnExplosion(o.x+o.w/2,GROUND_Y-o.h/2); break;
+      }
+    }
+  }
+}
+
+function addScore(pts) {
+  score += pts * buggy.scoreMultiplier;
+  hiScore = Math.max(hiScore, score);
+}
+
+// ── environment ───────────────────────────────────────────────────────────────
+let envState = {};
+
+function initEnv() {
+  envState = { dustTimer: 12, dustActive: false, dustAlpha: 0 };
+}
+
+function updateEnv(dt) {
+  const pl = PLANETS[planetIdx];
+  if (pl.envId === 'dust_storm') {
+    envState.dustTimer -= dt;
+    if (envState.dustTimer <= 0) {
+      if (envState.dustActive) {
+        envState.dustActive = false;
+        envState.dustTimer = 12 + Math.random() * 6;
+        for (const e of enemies) e.vx = -ENEMY_CFG[e.type].spd;
+      } else {
+        envState.dustActive = true;
+        envState.dustTimer = 4;
+        for (const e of enemies) e.vx *= 1.4;
+      }
+    }
+    const target = envState.dustActive ? 0.70 : 0;
+    envState.dustAlpha += (target - envState.dustAlpha) * 5 * dt;
+  }
+}
+
+function drawEnvOverlay() {
+  const pl = PLANETS[planetIdx];
+  if (typeof gravityReversed !== 'undefined' && gravityReversed) {
+    ctx.fillStyle = 'rgba(176,115,255,0.15)'; ctx.fillRect(0,0,W,H);
+    ctx.fillStyle='#b073ff'; ctx.font='bold 14px monospace'; ctx.textAlign='center';
+    ctx.fillText('⚠ GRAVITY REVERSED', W/2, H/2); ctx.textAlign='left';
+  }
+  if (pl.envId==='dust_storm' && envState.dustAlpha > 0.01) {
+    ctx.fillStyle=`rgba(180,80,0,${envState.dustAlpha*0.7})`; ctx.fillRect(0,0,W,H);
+    ctx.fillStyle=`rgba(220,120,40,${envState.dustAlpha*0.4})`;
+    for (let i=0;i<30;i++) {
+      ctx.fillRect(((i*137+frame*3)%W), 40+(i*73)%(GROUND_Y-80), 40+(i%4)*20, 2);
+    }
+  }
+}
+
+// ── particles & power-ups ─────────────────────────────────────────────────────
+let particles = [];
+let powerups = [];
+
+function spawnExplosion(x, y) {
+  const colors = ['#ffd866','#ff9a3c','#c04020','#ffffff'];
+  for (let i=0;i<14;i++) {
+    const angle=Math.random()*Math.PI*2, spd=80+Math.random()*220;
+    particles.push({x,y,vx:Math.cos(angle)*spd,vy:Math.sin(angle)*spd-60,
+      color:colors[Math.floor(Math.random()*4)],life:0.5+Math.random()*0.4,maxLife:0.9,r:2+Math.random()*3});
+  }
+}
+
+function updateParticles(dt) {
+  for (let i=particles.length-1;i>=0;i--) {
+    const p=particles[i];
+    p.x+=p.vx*dt; p.y+=p.vy*dt; p.vy+=300*dt; p.life-=dt;
+    if (p.life<=0) particles.splice(i,1);
+  }
+}
+
+function drawParticles() {
+  for (const p of particles) {
+    ctx.globalAlpha=Math.max(0,p.life/p.maxLife);
+    ctx.fillStyle=p.color;
+    ctx.beginPath(); ctx.arc(p.x-scrollX,p.y,p.r,0,Math.PI*2); ctx.fill();
+  }
+  ctx.globalAlpha=1;
+}
+
+function spawnPowerup(x, y) {
+  if (Math.random()>0.20) return;
+  const types=['rapid_fire','shield','missile','score_x2'];
+  powerups.push({type:types[Math.floor(Math.random()*4)],x,y:y-10,w:16,h:16,timer:5});
+}
+
+const PU_COLORS={rapid_fire:'#ffd866',shield:'#5ef0ff',missile:'#ff2bd6',score_x2:'#7dffae'};
+const PU_LABELS={rapid_fire:'⚡',shield:'🛡',missile:'🚀',score_x2:'×2'};
+
+function updatePowerups(dt) {
+  for (let i=powerups.length-1;i>=0;i--) {
+    const p=powerups[i]; p.timer-=dt;
+    if (p.timer<=0) { powerups.splice(i,1); continue; }
+    if (aabb({x:buggy.x,y:buggy.y,w:BUGGY_W,h:BUGGY_H},{x:p.x,y:p.y,w:p.w,h:p.h})) {
+      applyPowerup(p.type); powerups.splice(i,1);
+    }
+  }
+}
+
+function applyPowerup(type) {
+  if (type==='rapid_fire') { buggy.rapidFire=true; buggy.rapidTimer=8; }
+  else if (type==='shield') { buggy.shield=true; }
+  else if (type==='missile') { buggy.missiles=Math.min(buggy.missiles+3,9); }
+  else if (type==='score_x2') { buggy.scoreMultiplier=2; buggy.scoreMultTimer=12; }
+}
+
+function drawPowerups() {
+  for (const p of powerups) {
+    const sx=p.x-scrollX;
+    if (sx<-30||sx>W+30) continue;
+    if (p.timer<1.5&&Math.floor(frame/4)%2===0) continue;
+    ctx.fillStyle=PU_COLORS[p.type]; ctx.fillRect(sx,p.y,p.w,p.h);
+    ctx.strokeStyle='#fff'; ctx.lineWidth=1; ctx.strokeRect(sx,p.y,p.w,p.h);
+    ctx.fillStyle='#000'; ctx.font='10px monospace'; ctx.fillText(PU_LABELS[p.type],sx+2,p.y+12);
+  }
+}
+
+// ── boss system ───────────────────────────────────────────────────────────────
+let boss = null;
+
+const BOSS_CFG = {
+  lunar_fortress:   { w:180, h:80,  maxHp:30 },
+  storm_titan:      { w:160, h:120, maxHp:40 },
+  glacial_sentinel: { w:100, h:160, maxHp:40 },
+  the_overseer:     { w:140, h:140, maxHp:60 },
+};
+
+function startBoss() {
+  const pl=PLANETS[planetIdx], cfg=BOSS_CFG[pl.bossId];
+  state=S.BOSS; enemies=[]; bullets=[];
+  boss={type:pl.bossId, x:scrollX+W+40, y:GROUND_Y-cfg.h,
+        w:cfg.w, h:cfg.h, hp:cfg.maxHp, maxHp:cfg.maxHp,
+        phase:0, phaseTimer:0, attackTimer:0, vx:-60, vy:0};
+}
+
+function updateBoss(dt) {
+  if (!boss) return;
+  boss.phaseTimer+=dt; boss.attackTimer-=dt;
+  switch(boss.type) {
+    case 'lunar_fortress':   updateLunarFortress(dt); break;
+    case 'storm_titan':      updateStormTitan(dt); break;
+    case 'glacial_sentinel': updateGlacialSentinel(dt); break;
+    case 'the_overseer':     updateOverseer(dt); break;
+  }
+  for (let bi=bullets.length-1;bi>=0;bi--) {
+    const b=bullets[bi];
+    if (b.owner==='enemy') continue;
+    if (aabb({x:b.x,y:b.y,w:b.w,h:b.h},{x:boss.x,y:boss.y,w:boss.w,h:boss.h})) {
+      if (bossWeakPointHit(b)) {
+        boss.hp--; bullets.splice(bi,1); spawnExplosion(b.x,b.y);
+        if (boss.hp<=0) { defeatBoss(); return; }
+      } else { bullets.splice(bi,1); }
+    }
+  }
+  if (aabb({x:buggy.x,y:buggy.y,w:BUGGY_W,h:BUGGY_H},{x:boss.x,y:boss.y,w:boss.w,h:boss.h})) killBuggy();
+}
+
+function bossWeakPointHit(bullet) {
+  if (!boss) return false;
+  if (boss.type==='lunar_fortress') {
+    const hx=boss.x+boss.w*0.4, hw=boss.w*0.2;
+    return boss.phase===0 && bullet.x>=hx && bullet.x<=hx+hw;
+  }
+  if (boss.type==='storm_titan') return boss.phase<2;
+  if (boss.type==='glacial_sentinel') return boss.phaseTimer>1;
+  if (boss.type==='the_overseer') return boss.phase!==1||enemies.length===0;
+  return true;
+}
+
+function defeatBoss() {
+  addScore(PTS.boss);
+  if (!deathOnThisPlanet) addScore(PTS.planet_nodeath);
+  const bx=boss.x, by=boss.y, bw=boss.w, bh=boss.h;
+  for (let i=0;i<8;i++) setTimeout(()=>spawnExplosion(bx+Math.random()*bw,by+Math.random()*bh),i*120);
+  boss=null;
+  if (planetIdx<PLANETS.length-1) {
+    planetIdx++; obstacles=generateObstacles(planetIdx);
+    enemies=[]; bullets=[]; powerups=[]; scrollX=0; progress=0; deathOnThisPlanet=false;
+    initEnv(); state=S.PLANET_CLEAR;
+    setTimeout(()=>{ state=S.PLANET_INTRO; setTimeout(()=>{ state=S.PLAYING; },2500); },3000);
+  } else {
+    state=S.VICTORY; hiScore=Math.max(hiScore,score); localStorage.setItem('mpr_hi',hiScore);
+  }
+}
+
+function drawBoss() {
+  if (!boss) return;
+  const sx=boss.x-scrollX;
+  ctx.fillStyle='#7a3a00'; ctx.fillRect(sx,boss.y,boss.w,boss.h);
+  ctx.strokeStyle='#ff9a3c'; ctx.lineWidth=2; ctx.strokeRect(sx,boss.y,boss.w,boss.h);
+  ctx.fillStyle='#333'; ctx.fillRect(sx,boss.y-14,boss.w,8);
+  ctx.fillStyle='#c04020'; ctx.fillRect(sx,boss.y-14,boss.w*(boss.hp/boss.maxHp),8);
+  ctx.strokeStyle='#ffd866'; ctx.lineWidth=1; ctx.strokeRect(sx,boss.y-14,boss.w,8);
+  ctx.fillStyle='#ffd866'; ctx.font='10px monospace';
+  ctx.fillText(boss.type.toUpperCase().replace(/_/g,' '),sx,boss.y-18);
+}
+
+function updateLunarFortress(dt) {
+  if (boss.x > scrollX+W*0.6) { boss.x+=boss.vx*dt; return; }
+  boss.vx=0;
+  if (boss.phase===0) {
+    if (boss.attackTimer<=0) {
+      boss.attackTimer=3;
+      spawnEnemy('ufo_scout',boss.x+boss.w*0.4,boss.y);
+      spawnEnemy('ufo_scout',boss.x+boss.w*0.6,boss.y);
+    }
+    if (boss.hp<=boss.maxHp*0.67) { boss.phase=1; boss.phaseTimer=0; boss.attackTimer=2; }
+  }
+  if (boss.phase===1) {
+    if (boss.attackTimer<=0) {
+      boss.attackTimer=1.8;
+      const dx=buggy.x-(boss.x+boss.w/2), dy=GROUND_Y-(boss.y+boss.h), t=1.2;
+      bullets.push({x:boss.x+boss.w/2,y:boss.y+boss.h,vx:dx/t,vy:dy/t-360*t,w:10,h:10,owner:'enemy'});
+    }
+    if (boss.hp<=boss.maxHp*0.33) { boss.phase=2; boss.phaseTimer=0; boss.vx=-180; }
+  }
+  if (boss.phase===2) {
+    boss.x+=boss.vx*dt;
+    if (boss.x<scrollX-50) { boss.x=scrollX+W+40; boss.vx=-180; }
+  }
+}
+
+function updateStormTitan(dt) {
+  const targetY=80;
+  if (boss.phase<2) boss.y+=(targetY-boss.y)*3*dt;
+  if (boss.phase===0) {
+    if (boss.attackTimer<=0) {
+      boss.attackTimer=2;
+      const cx=boss.x+boss.w/2;
+      for (let a=-0.25;a<=0.25;a+=0.25)
+        bullets.push({x:cx,y:boss.y+boss.h,vx:Math.sin(a)*180,vy:240,w:8,h:8,owner:'enemy'});
+    }
+    if (boss.hp<=boss.maxHp*0.67) { boss.phase=1; boss.phaseTimer=0; boss.attackTimer=1; }
+  }
+  if (boss.phase===1) {
+    if (boss.phaseTimer<1.2) {
+      boss.y+=400*dt;
+      if (boss.y+boss.h>=GROUND_Y) { boss.y=GROUND_Y-boss.h; boss.phaseTimer=1.2; }
+    } else {
+      boss.y-=300*dt;
+      if (boss.y<=targetY) { boss.y=targetY; boss.phaseTimer=0; boss.attackTimer=1.5; }
+    }
+    if (boss.hp<=boss.maxHp*0.33) { boss.phase=2; boss.phaseTimer=0; boss.attackTimer=1; if (typeof envState!=='undefined') { envState.dustActive=true; envState.dustAlpha=0.7; } }
+  }
+  if (boss.phase===2) {
+    boss.y+=(targetY-boss.y)*3*dt;
+    if (boss.attackTimer<=0) {
+      boss.attackTimer=3;
+      spawnEnemy('dive_bomber',boss.x+boss.w*0.3,boss.y+boss.h);
+      spawnEnemy('dive_bomber',boss.x+boss.w*0.6,boss.y+boss.h);
+    }
+  }
+}
+
+function updateGlacialSentinel(dt) {
+  const spd=boss.phase===2?90:60;
+  boss.x-=spd*dt;
+  if (boss.x<scrollX+40) boss.x=scrollX+40;
+  if (boss.phase===0) {
+    if (boss.attackTimer<=0) {
+      boss.attackTimer=2.8;
+      for (let a=-0.4;a<=0.4;a+=0.2)
+        bullets.push({x:boss.x,y:boss.y+boss.h*0.5,vx:-180+Math.cos(a)*120,vy:Math.sin(a)*180,w:8,h:8,owner:'enemy'});
+      obstacles.push({type:'ice_wall',x:scrollX+400,w:18,h:40});
+    }
+    if (boss.hp<=boss.maxHp*0.67) { boss.phase=1; boss.phaseTimer=0; }
+  }
+  if (boss.phase===1) {
+    if (boss.phaseTimer>=0.7) {
+      bullets.push({x:boss.x-20,y:GROUND_Y-12,vx:-350,vy:0,w:30,h:20,owner:'enemy'});
+      boss.phase=0; boss.phaseTimer=0;
+    }
+    if (boss.hp<=boss.maxHp*0.33) boss.phase=2;
+  }
+}
+
+function updateOverseer(dt) {}
+
+// ── planet clear overlay ──────────────────────────────────────────────────────
+function drawPlanetClear() {
+  ctx.fillStyle = 'rgba(0,0,0,0.55)'; ctx.fillRect(0,0,W,H);
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 40px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('PLANET CLEAR!', W/2, H/2 - 20);
+  ctx.font = '18px monospace'; ctx.fillStyle = '#ff9a3c';
+  ctx.fillText('NEXT PATROL ZONE IN...', W/2, H/2 + 30);
+  ctx.textAlign = 'left';
+}
 
 function drawHUD() {
-  ctx.fillStyle = 'rgba(0,0,0,0.55)';
-  ctx.fillRect(0, 0, W, 44);
-  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 13px monospace';
-  ctx.fillText('SCORE ' + String(score).padStart(7,'0'), 12, 17);
-  ctx.fillStyle = '#ff9a3c';
-  ctx.fillText('HI ' + String(hiScore).padStart(7,'0'), 12, 32);
-  ctx.fillStyle = PLANETS[planetIdx].palette.text;
-  ctx.textAlign = 'center'; ctx.fillText(PLANETS[planetIdx].name, W/2, 17); ctx.textAlign = 'left';
-  ctx.fillStyle = '#ffd866';
-  ctx.fillText('LIVES ' + '♥'.repeat(Math.max(0,lives)), W - 140, 17);
-  const barX=80, barY=44, barW=W-160, barH=6;
+  const pl = PLANETS[planetIdx];
+  ctx.fillStyle='rgba(0,0,0,0.60)'; ctx.fillRect(0,0,W,44);
+  ctx.font='bold 13px monospace';
+  ctx.fillStyle='#ffd866'; ctx.fillText('SCORE '+String(score).padStart(7,'0'),12,17);
+  ctx.fillStyle='#ff9a3c'; ctx.fillText('HI '+String(hiScore).padStart(7,'0'),12,32);
+  ctx.fillStyle=pl.palette.text; ctx.textAlign='center'; ctx.fillText(pl.name,W/2,17); ctx.textAlign='left';
+  ctx.fillStyle='#ffd866'; ctx.fillText('LIVES '+'♥'.repeat(Math.max(0,lives)),W-140,17);
+  let px=W-140;
+  if (buggy.shield)       { ctx.fillStyle='#5ef0ff'; ctx.fillText('SHLD',px,32); px+=44; }
+  if (buggy.rapidFire)    { ctx.fillStyle='#ffd866'; ctx.fillText('RPID',px,32); px+=44; }
+  if (buggy.missiles>0)   { ctx.fillStyle='#ff2bd6'; ctx.fillText('MSL×'+buggy.missiles,px,32); }
+  const barX=80,barY=44,barW=W-160,barH=6;
   ctx.fillStyle='#1a0900'; ctx.fillRect(barX,barY,barW,barH);
-  ctx.fillStyle=PLANETS[planetIdx].palette.groundTop; ctx.fillRect(barX,barY,barW*progress,barH);
+  ctx.fillStyle=pl.palette.groundTop; ctx.fillRect(barX,barY,barW*progress,barH);
   ctx.fillStyle='#ff9a3c'; ctx.font='10px monospace';
   ctx.fillText('A',barX-14,barY+7); ctx.fillText('Z',barX+barW+4,barY+7);
   ctx.fillStyle='#c04020'; ctx.fillText('BOSS▸',barX+barW-36,barY-2);

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -102,6 +102,55 @@ class AudioMan {
 const audio = new AudioMan();
 audio.load({ cannon: 'sounds/cannon.wav', boom: 'sounds/boom.wav' });
 
+// ── asset loader ──────────────────────────────────────────────────────────────
+const IMGS = {};
+
+function keyWhite(img) {
+  const c = document.createElement('canvas');
+  c.width = img.width; c.height = img.height;
+  const gx = c.getContext('2d', { willReadFrequently: true });
+  gx.drawImage(img, 0, 0);
+  let id;
+  try { id = gx.getImageData(0, 0, c.width, c.height); } catch(e) { return img; }
+  const d = id.data;
+  if (d[3] < 250 || d[0] < 230) return img;
+  for (let i = 0; i < d.length; i += 4) {
+    const dist = 765 - d[i] - d[i+1] - d[i+2];
+    if (dist <= 8) { d[i+3] = 0; }
+    else if (dist <= 30) { d[i+3] = Math.floor(255 * (dist - 8) / 22); }
+  }
+  gx.putImageData(id, 0, 0);
+  return c;
+}
+
+async function loadImg(src) {
+  return new Promise(res => {
+    const img = new Image();
+    img.onload = () => res(keyWhite(img));
+    img.onerror = () => res(null);
+    img.src = src;
+  });
+}
+
+async function loadAssets() {
+  const entries = [
+    ['buggy',              'images/buggy.png'],
+    ['ufo_scout',          'images/ufo.png'],
+    ['moon_tank',          'images/moon_tank.png'],
+    ['sand_crawler',       'images/sand_crawler.png'],
+    ['dive_bomber',        'images/dive_bomber.png'],
+    ['ice_drone',          'images/ice_drone.png'],
+    ['cryo_turret',        'images/cryo_turret.png'],
+    ['phantom_drone',      'images/phantom_drone.png'],
+    ['orbital_mine',       'images/orbital_mine.png'],
+    ['boss_lunar_fortress','images/boss_lunar_fortress.png'],
+    ['boss_storm_titan',   'images/boss_storm_titan.png'],
+    ['boss_glacial_sentinel','images/boss_glacial_sentinel.png'],
+    ['boss_overseer',      'images/boss_overseer.png'],
+  ];
+  await Promise.all(entries.map(async ([k, src]) => { IMGS[k] = await loadImg(src); }));
+}
+
 // ── game variables ────────────────────────────────────────────────────────────
 let planetIdx, score, lives, hiScore, progress, scrollX, frame;
 let deathOnThisPlanet;
@@ -220,15 +269,20 @@ function drawBuggy() {
   if (state === S.DYING && Math.floor(frame / 4) % 2 === 0) return;
   const b = buggy;
   const sx = b.x - scrollX;
-  ctx.fillStyle = buggy.shield ? '#5ef0ff' : '#ff9a3c';
-  ctx.fillRect(sx, b.y, BUGGY_W, BUGGY_H);
-  ctx.fillStyle = '#ffd866';
-  ctx.beginPath(); ctx.arc(sx + 12, b.y + BUGGY_H, 8, 0, Math.PI*2); ctx.fill();
-  ctx.beginPath(); ctx.arc(sx + 40, b.y + BUGGY_H, 8, 0, Math.PI*2); ctx.fill();
-  // gun barrels
-  ctx.fillStyle = '#ffd866';
-  ctx.fillRect(sx + BUGGY_W, b.y + 8, 10, 3);   // forward
-  ctx.fillRect(sx + 30, b.y - 8, 3, 10);          // upward
+  if (IMGS.buggy) {
+    if (buggy.shield) { ctx.globalAlpha = 0.7; ctx.fillStyle = '#5ef0ff'; ctx.fillRect(sx-2, b.y-2, BUGGY_W+4, BUGGY_H+4); ctx.globalAlpha = 1; }
+    ctx.drawImage(IMGS.buggy, sx, b.y, BUGGY_W, BUGGY_H);
+  } else {
+    ctx.fillStyle = buggy.shield ? '#5ef0ff' : '#ff9a3c';
+    ctx.fillRect(sx, b.y, BUGGY_W, BUGGY_H);
+    ctx.fillStyle = '#ffd866';
+    ctx.beginPath(); ctx.arc(sx + 12, b.y + BUGGY_H, 8, 0, Math.PI*2); ctx.fill();
+    ctx.beginPath(); ctx.arc(sx + 40, b.y + BUGGY_H, 8, 0, Math.PI*2); ctx.fill();
+    // gun barrels
+    ctx.fillStyle = '#ffd866';
+    ctx.fillRect(sx + BUGGY_W, b.y + 8, 10, 3);   // forward
+    ctx.fillRect(sx + 30, b.y - 8, 3, 10);          // upward
+  }
 }
 
 // ── obstacles ─────────────────────────────────────────────────────────────────
@@ -523,8 +577,12 @@ function drawEnemies() {
     if (!e.visible) continue;
     const sx = e.x - scrollX;
     if (sx > W+50 || sx+e.w < -50) continue;
-    ctx.fillStyle = (e.type.includes('ufo')||e.type.includes('drone')||e.type==='orbital_mine') ? '#ff2bd6' : '#7dffae';
-    ctx.fillRect(sx, e.y, e.w, e.h);
+    if (IMGS[e.type]) {
+      ctx.drawImage(IMGS[e.type], sx, e.y, e.w, e.h);
+    } else {
+      ctx.fillStyle = (e.type.includes('ufo')||e.type.includes('drone')||e.type==='orbital_mine') ? '#ff2bd6' : '#7dffae';
+      ctx.fillRect(sx, e.y, e.w, e.h);
+    }
     if (e.maxHp > 1) {
       ctx.fillStyle='#333'; ctx.fillRect(sx,e.y-6,e.w,4);
       ctx.fillStyle='#f44'; ctx.fillRect(sx,e.y-6,e.w*(e.hp/e.maxHp),4);
@@ -758,8 +816,13 @@ function defeatBoss() {
 function drawBoss() {
   if (!boss) return;
   const sx=boss.x-scrollX;
-  ctx.fillStyle='#7a3a00'; ctx.fillRect(sx,boss.y,boss.w,boss.h);
-  ctx.strokeStyle='#ff9a3c'; ctx.lineWidth=2; ctx.strokeRect(sx,boss.y,boss.w,boss.h);
+  const bossImgKey = 'boss_' + boss.type;
+  if (IMGS[bossImgKey]) {
+    ctx.drawImage(IMGS[bossImgKey], sx, boss.y, boss.w, boss.h);
+  } else {
+    ctx.fillStyle='#7a3a00'; ctx.fillRect(sx,boss.y,boss.w,boss.h);
+    ctx.strokeStyle='#ff9a3c'; ctx.lineWidth=2; ctx.strokeRect(sx,boss.y,boss.w,boss.h);
+  }
   // lunar fortress hatch indicator
   if (boss.type==='lunar_fortress' && boss.phase===0) {
     const hatchX = sx + boss.w*0.35, hatchW = boss.w*0.3, hatchH = 14;
@@ -1037,5 +1100,6 @@ function drawPaused() {
 }
 
 initGame();
+loadAssets();  // fire-and-forget; sprites used if present, skipped if null
 requestAnimationFrame(loop);
 })();

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -55,78 +55,6 @@ window.addEventListener('keydown', e => {
 });
 window.addEventListener('keyup', e => { keys[e.code] = false; });
 
-// ── obstacles ─────────────────────────────────────────────────────────────────
-let obstacles = [];
-
-function mulberry32(seed) {
-  return function() {
-    seed |= 0; seed = seed + 0x6D2B79F5 | 0;
-    let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
-    t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
-    return ((t ^ t >>> 14) >>> 0) / 4294967296;
-  };
-}
-
-function generateObstacles(pIdx) {
-  const pl = PLANETS[pIdx];
-  const result = [];
-  let wx = 600;
-  const rng = mulberry32(pIdx * 9999 + 1);
-  while (wx < pl.patrolPx - 400) {
-    wx += 300 + rng() * 400;
-    const type = pl.obstacles[Math.floor(rng() * pl.obstacles.length)];
-    if (type==='crater'||type==='ravine'||type==='crevasse'||type==='void_gap') {
-      result.push({ type, x:wx, w: type==='ravine' ? 60+rng()*40 : 32+rng()*30, h:30 });
-    } else {
-      result.push({ type, x:wx, w:18, h: (28 + rng() * 20) | 0 });
-    }
-  }
-  return result;
-}
-
-function getGroundY(worldX) {
-  for (const o of obstacles) {
-    if ((o.type==='crater'||o.type==='ravine'||o.type==='crevasse'||o.type==='void_gap')
-        && worldX >= o.x && worldX <= o.x + o.w) return H + 100;
-  }
-  return GROUND_Y;
-}
-
-function aabb(a, b) {
-  return a.x < b.x+b.w && a.x+a.w > b.x && a.y < b.y+b.h && a.y+a.h > b.y;
-}
-
-function killBuggy() {
-  if (buggy.shield) { buggy.shield = false; return; }
-  lives--;
-  if (lives <= 0) {
-    state = S.GAME_OVER; hiScore = Math.max(hiScore,score); localStorage.setItem('mpr_hi',hiScore); return;
-  }
-  deathOnThisPlanet = true;
-  state = S.DYING;
-  setTimeout(() => { respawnBuggy(); state = S.PLAYING; }, 1200);
-}
-
-function respawnBuggy() {
-  buggy.x=80; buggy.y=GROUND_Y-BUGGY_H; buggy.vx=150; buggy.vy=0;
-  buggy.onGround=true; buggy.shield=false; buggy.sliding=false;
-  buggy.rapidFire=false; buggy.missiles=0; buggy.scoreMultiplier=1;
-}
-
-function drawObstacles() {
-  for (const o of obstacles) {
-    const sx = o.x - scrollX;
-    if (sx > W+50 || sx+o.w < -50) continue;
-    const pl = PLANETS[planetIdx];
-    if (o.type==='crater'||o.type==='ravine'||o.type==='crevasse'||o.type==='void_gap') {
-      ctx.fillStyle='#000'; ctx.fillRect(sx,GROUND_Y,o.w,H-GROUND_Y);
-    } else {
-      ctx.fillStyle=pl.palette.groundTop; ctx.fillRect(sx,GROUND_Y-o.h,o.w,o.h);
-      ctx.strokeStyle=pl.palette.star; ctx.lineWidth=1; ctx.strokeRect(sx,GROUND_Y-o.h,o.w,o.h);
-    }
-  }
-}
-
 // ── buggy ─────────────────────────────────────────────────────────────────────
 const BUGGY_W = 52, BUGGY_H = 28;
 let buggy;
@@ -135,6 +63,7 @@ function initGame() {
   planetIdx = 0; score = 0; lives = 3; progress = 0; scrollX = 0; frame = 0;
   deathOnThisPlanet = false;
   obstacles = generateObstacles(0);
+  bullets = [];
   buggy = { x:80, y:GROUND_Y - BUGGY_H, vx:150, vy:0, onGround:true,
             sliding:false, slideTimer:0, shield:false,
             rapidFire:false, rapidTimer:0, missiles:0,
@@ -226,6 +155,122 @@ function drawBuggy() {
   ctx.fillRect(sx + 30, b.y - 8, 3, 10);          // upward
 }
 
+// ── obstacles ─────────────────────────────────────────────────────────────────
+let obstacles = [];
+
+function mulberry32(seed) {
+  return function() {
+    seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+    let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+    t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
+
+function generateObstacles(pIdx) {
+  const pl = PLANETS[pIdx];
+  const result = [];
+  let wx = 600;
+  const rng = mulberry32(pIdx * 9999 + 1);
+  while (wx < pl.patrolPx - 400) {
+    wx += 300 + rng() * 400;
+    const type = pl.obstacles[Math.floor(rng() * pl.obstacles.length)];
+    if (type==='crater'||type==='ravine'||type==='crevasse'||type==='void_gap') {
+      result.push({ type, x:wx, w: type==='ravine' ? 60+rng()*40 : 32+rng()*30, h:30 });
+    } else {
+      result.push({ type, x:wx, w:18, h: (28 + rng() * 20) | 0 });
+    }
+  }
+  return result;
+}
+
+function getGroundY(worldX) {
+  for (const o of obstacles) {
+    if ((o.type==='crater'||o.type==='ravine'||o.type==='crevasse'||o.type==='void_gap')
+        && worldX >= o.x && worldX <= o.x + o.w) return H + 100;
+  }
+  return GROUND_Y;
+}
+
+function aabb(a, b) {
+  return a.x < b.x+b.w && a.x+a.w > b.x && a.y < b.y+b.h && a.y+a.h > b.y;
+}
+
+function killBuggy() {
+  if (buggy.shield) { buggy.shield = false; return; }
+  lives--;
+  if (lives <= 0) {
+    state = S.GAME_OVER; hiScore = Math.max(hiScore,score); localStorage.setItem('mpr_hi',hiScore); return;
+  }
+  deathOnThisPlanet = true;
+  state = S.DYING;
+  setTimeout(() => { respawnBuggy(); state = S.PLAYING; }, 1200);
+}
+
+function respawnBuggy() {
+  buggy.x=80; buggy.y=GROUND_Y-BUGGY_H; buggy.vx=150; buggy.vy=0;
+  buggy.onGround=true; buggy.shield=false; buggy.sliding=false;
+  buggy.rapidFire=false; buggy.missiles=0; buggy.scoreMultiplier=1;
+}
+
+function drawObstacles() {
+  for (const o of obstacles) {
+    const sx = o.x - scrollX;
+    if (sx > W+50 || sx+o.w < -50) continue;
+    const pl = PLANETS[planetIdx];
+    if (o.type==='crater'||o.type==='ravine'||o.type==='crevasse'||o.type==='void_gap') {
+      ctx.fillStyle='#000'; ctx.fillRect(sx,GROUND_Y,o.w,H-GROUND_Y);
+    } else {
+      ctx.fillStyle=pl.palette.groundTop; ctx.fillRect(sx,GROUND_Y-o.h,o.w,o.h);
+      ctx.strokeStyle=pl.palette.star; ctx.lineWidth=1; ctx.strokeRect(sx,GROUND_Y-o.h,o.w,o.h);
+    }
+  }
+}
+
+// ── bullets ───────────────────────────────────────────────────────────────────
+let bullets = [];
+
+function fireBuggy() {
+  const cooldown = buggy.rapidFire ? 0.1 : 0.25;
+  if (buggy.fireTimer > 0) return;
+  buggy.fireTimer = cooldown;
+  bullets.push({ x:buggy.x+BUGGY_W, y:buggy.y+BUGGY_H*0.4, vx:700, vy:0, w:12, h:4, owner:'player' });
+  bullets.push({ x:buggy.x+BUGGY_W*0.6, y:buggy.y, vx:0, vy:-650, w:4, h:12, owner:'player' });
+  if (typeof audio !== 'undefined') audio.sfx('cannon',{rate:1.2,vol:0.4});
+}
+
+function fireMissile() {
+  if (buggy.missiles <= 0) return;
+  buggy.missiles--;
+  const targets = (typeof enemies !== 'undefined' ? enemies : []).filter(e=>e.y<GROUND_Y-40);
+  let tx=buggy.x+200, ty=buggy.y-200;
+  if (targets.length) {
+    const n=targets.reduce((a,b)=>Math.hypot(a.x-buggy.x,a.y-buggy.y)<Math.hypot(b.x-buggy.x,b.y-buggy.y)?a:b);
+    tx=n.x+n.w/2; ty=n.y+n.h/2;
+  }
+  const dx=tx-buggy.x, dy=ty-buggy.y, mag=Math.hypot(dx,dy)||1;
+  bullets.push({x:buggy.x+BUGGY_W*0.6,y:buggy.y,vx:dx/mag*600,vy:dy/mag*600,w:8,h:8,owner:'missile'});
+}
+
+function updateBullets(dt) {
+  for (const b of bullets) { b.x+=b.vx*dt; b.y+=b.vy*dt; }
+  for (let i=bullets.length-1;i>=0;i--) {
+    const b=bullets[i];
+    if (b.x>scrollX+W+60||b.x<scrollX-60||b.y<0||b.y>H) bullets.splice(i,1);
+  }
+}
+
+function drawBullets() {
+  for (const b of bullets) {
+    const sx = b.x - scrollX;
+    ctx.fillStyle = b.owner==='missile'?'#ff2bd6':b.owner==='player'?'#ffd866':'#ff4040';
+    ctx.shadowColor = ctx.fillStyle; ctx.shadowBlur = 6;
+    if (b.owner==='missile') ctx.fillRect(sx-b.w/2,b.y-b.h/2,b.w,b.h);
+    else ctx.fillRect(sx,b.y,b.w,b.h);
+    ctx.shadowBlur=0;
+  }
+}
+
 // ── loop ─────────────────────────────────────────────────────────────────────
 let lastTs = 0;
 function loop(ts) {
@@ -242,7 +287,7 @@ function update(dt) {
   if (state !== S.PLAYING && state !== S.BOSS && state !== S.DYING) return;
   if (typeof updateEnv === 'function') updateEnv(dt);
   updateBuggy(dt);
-  if (typeof updateBullets === 'function') updateBullets(dt);
+  updateBullets(dt);
   if (typeof updateEnemies === 'function') updateEnemies(dt);
   if (typeof checkCollisions === 'function') checkCollisions();
   if (typeof updatePowerups === 'function') updatePowerups(dt);
@@ -252,6 +297,11 @@ function update(dt) {
     scrollX += buggy.vx * dt;
     progress = Math.min(1, scrollX / PLANETS[planetIdx].patrolPx);
     if (progress >= 1 && typeof startBoss === 'function') startBoss();
+  }
+  // fire input
+  if (state===S.PLAYING||state===S.BOSS) {
+    if (keys['KeyZ']||keys['ControlLeft']||keys['ControlRight']) fireBuggy();
+    if (keys['KeyX']) fireMissile();
   }
 }
 
@@ -287,7 +337,7 @@ function draw() {
       drawObstacles();
       if (typeof drawPowerups === 'function') drawPowerups();
       if (typeof drawEnemies === 'function') drawEnemies();
-      if (typeof drawBullets === 'function') drawBullets();
+      drawBullets();
       drawBuggy();
       if (typeof drawParticles === 'function') drawParticles();
       if (typeof drawBoss === 'function' && state === S.BOSS) drawBoss();

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -146,7 +146,7 @@ async function loadAssets() {
     ['boss_lunar_fortress','images/boss_lunar_fortress.png'],
     ['boss_storm_titan',   'images/boss_storm_titan.png'],
     ['boss_glacial_sentinel','images/boss_glacial_sentinel.png'],
-    ['boss_overseer',      'images/boss_overseer.png'],
+    ['boss_the_overseer',  'images/boss_overseer.png'],
   ];
   await Promise.all(entries.map(async ([k, src]) => { IMGS[k] = await loadImg(src); }));
 }
@@ -186,6 +186,8 @@ function initGame() {
             sliding:false, slideTimer:0, shield:false,
             rapidFire:false, rapidTimer:0, missiles:0,
             scoreMultiplier:1, scoreMultTimer:0, fireTimer:0 };
+  gravityReversed = false;
+  gravRevTimer = 0;
   initEnv();
   state = S.PLANET_INTRO;
   Object.keys(keys).forEach(k => { keys[k] = false; });
@@ -344,6 +346,8 @@ function respawnBuggy() {
   buggy.onGround=true; buggy.shield=false; buggy.sliding=false;
   buggy.rapidFire=false; buggy.missiles=0; buggy.scoreMultiplier=1;
   buggy.fireTimer=0;
+  gravityReversed = false;
+  gravRevTimer = 0;
 }
 
 function drawObstacles() {
@@ -803,6 +807,8 @@ function defeatBoss() {
   const bx=boss.x, by=boss.y, bw=boss.w, bh=boss.h;
   for (let i=0;i<8;i++) setTimeout(()=>spawnExplosion(bx+Math.random()*bw,by+Math.random()*bh),i*120);
   boss=null;
+  gravityReversed = false;
+  gravRevTimer = 0;
   if (planetIdx<PLANETS.length-1) {
     planetIdx++; obstacles=generateObstacles(planetIdx);
     enemies=[]; bullets=[]; powerups=[]; scrollX=0; progress=0; deathOnThisPlanet=false;
@@ -957,7 +963,7 @@ function updateOverseer(dt) {
   if (boss.phase === 0) {
     if (boss.attackTimer <= 0) {
       boss.attackTimer = 3.5;
-      bullets.push({ x: scrollX + W, y: GROUND_Y - 50, vx: -300, vy: 0, w: W, h: 14, owner: 'enemy' });
+      bullets.push({ x: scrollX + W, y: GROUND_Y - 14, vx: -300, vy: 0, w: 280, h: 14, owner: 'enemy' });
     }
     if (boss.hp <= boss.maxHp * 0.75) { boss.phase = 1; boss.phaseTimer = 0; enemies = []; }
   }

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -43,6 +43,101 @@ let planetIdx, score, lives, hiScore, progress, scrollX, frame;
 let deathOnThisPlanet;
 hiScore = parseInt(localStorage.getItem('mpr_hi') || '0');
 
+// ── input (stub — handlers added Task 4) ─────────────────────────────────────
+const keys = {};
+
+// ── buggy ─────────────────────────────────────────────────────────────────────
+const BUGGY_W = 52, BUGGY_H = 28;
+let buggy;
+
+function initGame() {
+  planetIdx = 0; score = 0; lives = 3; progress = 0; scrollX = 0; frame = 0;
+  deathOnThisPlanet = false;
+  buggy = { x:80, y:GROUND_Y - BUGGY_H, vx:150, vy:0, onGround:true,
+            sliding:false, slideTimer:0, shield:false,
+            rapidFire:false, rapidTimer:0, missiles:0,
+            scoreMultiplier:1, scoreMultTimer:0, fireTimer:0 };
+  state = S.PLANET_INTRO;
+  setTimeout(() => { state = S.PLAYING; }, 2500);
+}
+
+function updateBuggy(dt) {
+  const pl = PLANETS[planetIdx];
+  const grav = pl.gravity;
+
+  // zero-g upward drift
+  if (pl.envId === 'zero_g' && buggy.onGround) {
+    buggy.onGround = false;
+    buggy.vy = -80;
+  }
+  // downward thruster (Void only)
+  if (pl.envId === 'zero_g' && (keys['ArrowDown'] || keys['KeyS'])) {
+    buggy.vy += 600 * dt;
+  }
+
+  // acceleration / brake
+  const MIN_VX = 90, MAX_VX = 240;
+  if (!buggy.sliding) {
+    if (keys['ArrowRight'] || keys['KeyD']) buggy.vx = Math.min(MAX_VX, buggy.vx + 240 * dt);
+    else if (keys['ArrowLeft'] || keys['KeyA']) buggy.vx = Math.max(MIN_VX, buggy.vx - 180 * dt);
+    else buggy.vx += (150 - buggy.vx) * 3 * dt;
+  }
+
+  // jump
+  if ((keys['ArrowUp'] || keys['KeyW'] || keys['Space']) && buggy.onGround && pl.envId !== 'zero_g') {
+    buggy.vy = pl.envId === 'low_gravity' ? -380 : -420;
+    buggy.onGround = false;
+  }
+
+  // apply gravity
+  if (!buggy.onGround) {
+    buggy.vy += grav * dt;
+  }
+
+  buggy.x += buggy.vx * dt;
+  buggy.y += buggy.vy * dt;
+
+  // ground collision
+  const groundTop = getGroundY(buggy.x + BUGGY_W / 2);
+  if (buggy.y + BUGGY_H >= groundTop) {
+    buggy.y = groundTop - BUGGY_H;
+    if (pl.envId === 'ice_slide' && !buggy.onGround && Math.abs(buggy.vy) > 50) {
+      buggy.sliding = true; buggy.slideTimer = 0.8;
+    }
+    buggy.vy = 0;
+    buggy.onGround = true;
+  }
+
+  // ceiling
+  if (buggy.y < 44) { buggy.y = 44; buggy.vy = Math.max(0, buggy.vy); }
+
+  // ice slide decay
+  if (buggy.sliding) { buggy.slideTimer -= dt; if (buggy.slideTimer <= 0) buggy.sliding = false; }
+
+  // power-up timers
+  if (buggy.rapidFire) { buggy.rapidTimer -= dt; if (buggy.rapidTimer <= 0) buggy.rapidFire = false; }
+  if (buggy.scoreMultiplier > 1) { buggy.scoreMultTimer -= dt; if (buggy.scoreMultTimer <= 0) buggy.scoreMultiplier = 1; }
+  buggy.fireTimer = Math.max(0, buggy.fireTimer - dt);
+}
+
+// placeholder — real terrain in Task 5
+function getGroundY(worldX) { return GROUND_Y; }
+
+function drawBuggy() {
+  if (state === S.DYING && Math.floor(frame / 4) % 2 === 0) return;
+  const b = buggy;
+  const sx = b.x - scrollX;
+  ctx.fillStyle = buggy.shield ? '#5ef0ff' : '#ff9a3c';
+  ctx.fillRect(sx, b.y, BUGGY_W, BUGGY_H);
+  ctx.fillStyle = '#ffd866';
+  ctx.beginPath(); ctx.arc(sx + 12, b.y + BUGGY_H, 8, 0, Math.PI*2); ctx.fill();
+  ctx.beginPath(); ctx.arc(sx + 40, b.y + BUGGY_H, 8, 0, Math.PI*2); ctx.fill();
+  // gun barrels
+  ctx.fillStyle = '#ffd866';
+  ctx.fillRect(sx + BUGGY_W, b.y + 8, 10, 3);   // forward
+  ctx.fillRect(sx + 30, b.y - 8, 3, 10);          // upward
+}
+
 // ── loop ─────────────────────────────────────────────────────────────────────
 let lastTs = 0;
 function loop(ts) {
@@ -54,12 +149,21 @@ function loop(ts) {
   requestAnimationFrame(loop);
 }
 
-function update(dt) { /* filled in Task 4 */ }
+function update(dt) {
+  if (state === S.PAUSED) return;
+  if (state !== S.PLAYING && state !== S.BOSS && state !== S.DYING) return;
+  updateBuggy(dt);
+}
+
 function draw() {
   const pl = PLANETS[planetIdx || 0];
   ctx.fillStyle = pl.palette.sky;
   ctx.fillRect(0, 0, W, H);
+  if (state === S.PLAYING || state === S.BOSS || state === S.DYING) {
+    drawBuggy();
+  }
 }
 
+initGame();
 requestAnimationFrame(loop);
 })();

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -55,6 +55,78 @@ window.addEventListener('keydown', e => {
 });
 window.addEventListener('keyup', e => { keys[e.code] = false; });
 
+// ── obstacles ─────────────────────────────────────────────────────────────────
+let obstacles = [];
+
+function mulberry32(seed) {
+  return function() {
+    seed |= 0; seed = seed + 0x6D2B79F5 | 0;
+    let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+    t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
+
+function generateObstacles(pIdx) {
+  const pl = PLANETS[pIdx];
+  const result = [];
+  let wx = 600;
+  const rng = mulberry32(pIdx * 9999 + 1);
+  while (wx < pl.patrolPx - 400) {
+    wx += 300 + rng() * 400;
+    const type = pl.obstacles[Math.floor(rng() * pl.obstacles.length)];
+    if (type==='crater'||type==='ravine'||type==='crevasse'||type==='void_gap') {
+      result.push({ type, x:wx, w: type==='ravine' ? 60+rng()*40 : 32+rng()*30, h:30 });
+    } else {
+      result.push({ type, x:wx, w:18, h: (28 + rng() * 20) | 0 });
+    }
+  }
+  return result;
+}
+
+function getGroundY(worldX) {
+  for (const o of obstacles) {
+    if ((o.type==='crater'||o.type==='ravine'||o.type==='crevasse'||o.type==='void_gap')
+        && worldX >= o.x && worldX <= o.x + o.w) return H + 100;
+  }
+  return GROUND_Y;
+}
+
+function aabb(a, b) {
+  return a.x < b.x+b.w && a.x+a.w > b.x && a.y < b.y+b.h && a.y+a.h > b.y;
+}
+
+function killBuggy() {
+  if (buggy.shield) { buggy.shield = false; return; }
+  lives--;
+  if (lives <= 0) {
+    state = S.GAME_OVER; hiScore = Math.max(hiScore,score); localStorage.setItem('mpr_hi',hiScore); return;
+  }
+  deathOnThisPlanet = true;
+  state = S.DYING;
+  setTimeout(() => { respawnBuggy(); state = S.PLAYING; }, 1200);
+}
+
+function respawnBuggy() {
+  buggy.x=80; buggy.y=GROUND_Y-BUGGY_H; buggy.vx=150; buggy.vy=0;
+  buggy.onGround=true; buggy.shield=false; buggy.sliding=false;
+  buggy.rapidFire=false; buggy.missiles=0; buggy.scoreMultiplier=1;
+}
+
+function drawObstacles() {
+  for (const o of obstacles) {
+    const sx = o.x - scrollX;
+    if (sx > W+50 || sx+o.w < -50) continue;
+    const pl = PLANETS[planetIdx];
+    if (o.type==='crater'||o.type==='ravine'||o.type==='crevasse'||o.type==='void_gap') {
+      ctx.fillStyle='#000'; ctx.fillRect(sx,GROUND_Y,o.w,H-GROUND_Y);
+    } else {
+      ctx.fillStyle=pl.palette.groundTop; ctx.fillRect(sx,GROUND_Y-o.h,o.w,o.h);
+      ctx.strokeStyle=pl.palette.star; ctx.lineWidth=1; ctx.strokeRect(sx,GROUND_Y-o.h,o.w,o.h);
+    }
+  }
+}
+
 // ── buggy ─────────────────────────────────────────────────────────────────────
 const BUGGY_W = 52, BUGGY_H = 28;
 let buggy;
@@ -62,6 +134,7 @@ let buggy;
 function initGame() {
   planetIdx = 0; score = 0; lives = 3; progress = 0; scrollX = 0; frame = 0;
   deathOnThisPlanet = false;
+  obstacles = generateObstacles(0);
   buggy = { x:80, y:GROUND_Y - BUGGY_H, vx:150, vy:0, onGround:true,
             sliding:false, slideTimer:0, shield:false,
             rapidFire:false, rapidTimer:0, missiles:0,
@@ -120,6 +193,15 @@ function updateBuggy(dt) {
   // ceiling
   if (buggy.y < 44) { buggy.y = 44; buggy.vy = Math.max(0, buggy.vy); }
 
+  // solid obstacle collision
+  for (const o of obstacles) {
+    const isSolid = o.type==='lunar_rock'||o.type==='rock_spire'||o.type==='ice_wall';
+    if (!isSolid) continue;
+    if (aabb({x:buggy.x,y:buggy.y,w:BUGGY_W,h:BUGGY_H},{x:o.x,y:GROUND_Y-o.h,w:o.w,h:o.h})) {
+      killBuggy(); return;
+    }
+  }
+
   // ice slide decay
   if (buggy.sliding) { buggy.slideTimer -= dt; if (buggy.slideTimer <= 0) buggy.sliding = false; }
 
@@ -128,9 +210,6 @@ function updateBuggy(dt) {
   if (buggy.scoreMultiplier > 1) { buggy.scoreMultTimer -= dt; if (buggy.scoreMultTimer <= 0) buggy.scoreMultiplier = 1; }
   buggy.fireTimer = Math.max(0, buggy.fireTimer - dt);
 }
-
-// placeholder — overridden in Task 5
-function getGroundY(worldX) { return GROUND_Y; }
 
 function drawBuggy() {
   if (state === S.DYING && Math.floor(frame / 4) % 2 === 0) return;
@@ -205,7 +284,7 @@ function draw() {
     default:
       ctx.fillStyle = pl.palette.sky; ctx.fillRect(0,0,W,H);
       drawStars(pl); drawGround(pl);
-      if (typeof drawObstacles === 'function') drawObstacles();
+      drawObstacles();
       if (typeof drawPowerups === 'function') drawPowerups();
       if (typeof drawEnemies === 'function') drawEnemies();
       if (typeof drawBullets === 'function') drawBullets();

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -1073,19 +1073,73 @@ function drawTitle() {
   const pl = PLANETS[0];
   ctx.fillStyle = pl.palette.sky; ctx.fillRect(0, 0, W, H);
   if (typeof drawStars === 'function') drawStars(pl);
+
+  // ── title ──────────────────────────────────────────────────────────────────
   ctx.textAlign = 'center';
-  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 48px monospace';
-  ctx.fillText('MOON PATROL', W/2, 220);
-  ctx.fillStyle = '#ff9a3c'; ctx.font = 'bold 18px monospace';
-  ctx.fillText('// RECON', W/2, 256);
-  if (Math.floor(Date.now() / 600) % 2 === 0) {
-    ctx.fillStyle = '#c8c8d0'; ctx.font = '14px monospace';
-    ctx.fillText('PRESS SPACE OR ENTER TO START', W/2, 340);
-  }
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 52px monospace';
+  ctx.fillText('MOON PATROL', W/2, 100);
+  ctx.fillStyle = '#ff9a3c'; ctx.font = 'bold 20px monospace';
+  ctx.fillText('// RECON', W/2, 130);
+
+  // ── divider ────────────────────────────────────────────────────────────────
+  ctx.strokeStyle = 'rgba(255,154,60,0.3)'; ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.moveTo(60, 148); ctx.lineTo(W - 60, 148); ctx.stroke();
+
+  // ── controls table ────────────────────────────────────────────────────────
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 11px monospace';
+  ctx.fillText('CONTROLS', W/2, 172);
+
+  const controls = [
+    ['← / A  →/ D',  'Brake / Accelerate'],
+    ['↑ / W / SPACE', 'Jump  (hold for higher)'],
+    ['↓ / S',         'Downward thruster  (The Void only)'],
+    ['Z / CTRL',      'Fire — forward + upward cannon'],
+    ['X',             'Launch homing missile  (collect first)'],
+    ['P',             'Pause / Resume'],
+  ];
+  const colK = W/2 - 220, colV = W/2 - 10;
+  ctx.textAlign = 'left';
+  controls.forEach(([key, desc], i) => {
+    const y = 196 + i * 22;
+    ctx.fillStyle = '#ffd866'; ctx.font = '12px monospace';
+    ctx.fillText(key, colK, y);
+    ctx.fillStyle = 'rgba(255,154,60,0.7)'; ctx.font = '12px monospace';
+    ctx.fillText(desc, colV, y);
+  });
+
+  // ── divider ────────────────────────────────────────────────────────────────
+  ctx.strokeStyle = 'rgba(255,154,60,0.3)';
+  ctx.beginPath(); ctx.moveTo(60, 334); ctx.lineTo(W - 60, 334); ctx.stroke();
+
+  // ── planets strip ─────────────────────────────────────────────────────────
+  ctx.textAlign = 'center';
+  ctx.fillStyle = 'rgba(255,154,60,0.5)'; ctx.font = 'bold 10px monospace';
+  ctx.fillText('4 PLANETS  ·  4 BOSSES  ·  3 LIVES', W/2, 352);
+  const planets = [
+    { name:'MOON',    color:'#c8c8d0', sub:'LOW GRAVITY' },
+    { name:'MARS',    color:'#e06030', sub:'DUST STORM' },
+    { name:'EUROPA',  color:'#80c0ff', sub:'ICY SURFACE' },
+    { name:'THE VOID',color:'#b073ff', sub:'ZERO-G' },
+  ];
+  planets.forEach((p, i) => {
+    const x = 120 + i * 185;
+    ctx.fillStyle = p.color; ctx.font = 'bold 12px monospace';
+    ctx.fillText(p.name, x, 374);
+    ctx.fillStyle = 'rgba(255,154,60,0.5)'; ctx.font = '10px monospace';
+    ctx.fillText(p.sub, x, 388);
+  });
+
+  // ── divider ────────────────────────────────────────────────────────────────
+  ctx.strokeStyle = 'rgba(255,154,60,0.3)';
+  ctx.beginPath(); ctx.moveTo(60, 404); ctx.lineTo(W - 60, 404); ctx.stroke();
+
+  // ── hi-score + start prompt ───────────────────────────────────────────────
   ctx.fillStyle = '#ff9a3c'; ctx.font = '12px monospace';
-  ctx.fillText('HI-SCORE  ' + String(hiScore).padStart(7,'0'), W/2, 380);
-  ctx.fillStyle = '#7a4000'; ctx.font = '11px monospace';
-  ctx.fillText('← → DRIVE   ↑ JUMP   Z FIRE   X MISSILE   P PAUSE', W/2, 430);
+  ctx.fillText('HI-SCORE  ' + String(hiScore).padStart(7, '0'), W/2, 424);
+  if (Math.floor(Date.now() / 600) % 2 === 0) {
+    ctx.fillStyle = '#ffd866'; ctx.font = 'bold 14px monospace';
+    ctx.fillText('PRESS  SPACE  OR  ENTER  TO  START', W/2, 450);
+  }
   ctx.textAlign = 'left';
 }
 

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -209,6 +209,7 @@ function aabb(a, b) {
 function killBuggy() {
   if (state === S.DYING || state === S.GAME_OVER) return;
   if (buggy.shield) { buggy.shield = false; return; }
+  paused = false;
   lives--;
   if (lives <= 0) {
     state = S.GAME_OVER; hiScore = Math.max(hiScore,score); localStorage.setItem('mpr_hi',hiScore); return;

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -8,8 +8,8 @@ const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 
 // ── state ────────────────────────────────────────────────────────────────────
-const S = { LOADING:'LOADING', TITLE:'TITLE', PLANET_INTRO:'PLANET_INTRO',
-            PLAYING:'PLAYING', BOSS:'BOSS', DYING:'DYING', PAUSED:'PAUSED',
+const S = { TITLE:'TITLE', PLANET_INTRO:'PLANET_INTRO',
+            PLAYING:'PLAYING', BOSS:'BOSS', DYING:'DYING',
             PLANET_CLEAR:'PLANET_CLEAR', GAME_OVER:'GAME_OVER', VICTORY:'VICTORY' };
 let state = S.TITLE;
 
@@ -48,8 +48,11 @@ class AudioMan {
     this.master.connect(this.ctx.destination);
     this.sfxG = this.ctx.createGain(); this.sfxG.gain.value = 0.7;
     this.sfxG.connect(this.master);
+    this.musicG = this.ctx.createGain(); this.musicG.gain.value = 0.22;
+    this.musicG.connect(this.master);
     this.bufs = {};
     this.engineNode = null; this.engineGain = null; this._lfo = null;
+    this.musicSource = null; this.currentMusicKey = null; this.pendingMusic = null;
   }
 
   resume() { if (this.ctx?.state === 'suspended') this.ctx.resume(); }
@@ -64,6 +67,11 @@ class AudioMan {
         this.bufs[k] = await this.ctx.decodeAudioData(ab);
       } catch(e) { console.warn('audio load fail', url); }
     }));
+    if (this.pendingMusic) {
+      const { key, options } = this.pendingMusic;
+      this.pendingMusic = null;
+      this.startMusic(key, options);
+    }
   }
 
   sfx(key, { rate = 1, vol = 0.6 } = {}) {
@@ -90,7 +98,35 @@ class AudioMan {
 
   stopEngine() {
     try { this.engineNode?.stop(); this._lfo?.stop(); } catch(e) {}
-    this.engineNode = null; this._lfo = null;
+    try { this.engineGain?.disconnect(); } catch(e) {}
+    this.engineNode = null; this._lfo = null; this.engineGain = null;
+  }
+
+  startMusic(key, options = {}) {
+    if (!this.ctx) return;
+    const { vol = 0.22 } = options;
+    this.musicG.gain.value = vol;
+    if (!this.bufs[key]) {
+      this.pendingMusic = { key, options };
+      return;
+    }
+    if (this.musicSource && this.currentMusicKey === key) return;
+    this.stopMusic();
+    const s = this.ctx.createBufferSource();
+    s.buffer = this.bufs[key];
+    s.loop = true;
+    s.connect(this.musicG);
+    s.start();
+    this.musicSource = s;
+    this.currentMusicKey = key;
+  }
+
+  stopMusic() {
+    try { this.musicSource?.stop(); } catch(e) {}
+    try { this.musicSource?.disconnect(); } catch(e) {}
+    this.musicSource = null;
+    this.currentMusicKey = null;
+    this.pendingMusic = null;
   }
 
   setEngineSpeed(vx) {
@@ -100,7 +136,7 @@ class AudioMan {
 }
 
 const audio = new AudioMan();
-audio.load({ cannon: 'sounds/cannon.wav', boom: 'sounds/boom.wav' });
+audio.load({ cannon: 'sounds/cannon.wav', boom: 'sounds/boom.wav', music: 'sounds/music.ogg' });
 
 // ── asset loader ──────────────────────────────────────────────────────────────
 const IMGS = {};
@@ -189,6 +225,7 @@ function initGame() {
   gravityReversed = false;
   gravRevTimer = 0;
   initEnv();
+  audio.startMusic('music', { vol: 0.22 });
   state = S.PLANET_INTRO;
   Object.keys(keys).forEach(k => { keys[k] = false; });
   setTimeout(() => { if (state === S.PLANET_INTRO) state = S.PLAYING; }, 2500);
@@ -334,6 +371,7 @@ function killBuggy() {
   paused = false;
   lives--;
   if (lives <= 0) {
+    audio.stopMusic();
     state = S.GAME_OVER; hiScore = Math.max(hiScore,score); localStorage.setItem('mpr_hi',hiScore); return;
   }
   deathOnThisPlanet = true;
@@ -813,8 +851,9 @@ function defeatBoss() {
     planetIdx++; obstacles=generateObstacles(planetIdx);
     enemies=[]; bullets=[]; powerups=[]; scrollX=0; progress=0; deathOnThisPlanet=false;
     initEnv(); state=S.PLANET_CLEAR;
-    setTimeout(()=>{ state=S.PLANET_INTRO; setTimeout(()=>{ state=S.PLAYING; },2500); },3000);
+    setTimeout(()=>{ state=S.PLANET_INTRO; setTimeout(()=>{ if(state===S.PLANET_INTRO) state=S.PLAYING; },2500); },3000);
   } else {
+    audio.stopMusic();
     state=S.VICTORY; hiScore=Math.max(hiScore,score); localStorage.setItem('mpr_hi',hiScore);
   }
 }
@@ -1105,7 +1144,6 @@ function drawPaused() {
   ctx.textAlign = 'left';
 }
 
-initGame();
 loadAssets();  // fire-and-forget; sprites used if present, skipped if null
 requestAnimationFrame(loop);
 })();

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -43,8 +43,17 @@ let planetIdx, score, lives, hiScore, progress, scrollX, frame;
 let deathOnThisPlanet;
 hiScore = parseInt(localStorage.getItem('mpr_hi') || '0');
 
-// ── input (stub — handlers added Task 4) ─────────────────────────────────────
+// ── input ────────────────────────────────────────────────────────────────────
 const keys = {};
+window.addEventListener('keydown', e => {
+  keys[e.code] = true;
+  if (['Space','ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.code)) e.preventDefault();
+  if (e.code === 'KeyP' && state === S.PLAYING) state = S.PAUSED;
+  else if (e.code === 'KeyP' && state === S.PAUSED) state = S.PLAYING;
+  if ((e.code === 'Space' || e.code === 'Enter') && state === S.TITLE) initGame();
+  if ((e.code === 'Space' || e.code === 'Enter') && (state === S.GAME_OVER || state === S.VICTORY)) initGame();
+});
+window.addEventListener('keyup', e => { keys[e.code] = false; });
 
 // ── buggy ─────────────────────────────────────────────────────────────────────
 const BUGGY_W = 52, BUGGY_H = 28;
@@ -120,7 +129,7 @@ function updateBuggy(dt) {
   buggy.fireTimer = Math.max(0, buggy.fireTimer - dt);
 }
 
-// placeholder — real terrain in Task 5
+// placeholder — overridden in Task 5
 function getGroundY(worldX) { return GROUND_Y; }
 
 function drawBuggy() {
@@ -152,16 +161,173 @@ function loop(ts) {
 function update(dt) {
   if (state === S.PAUSED) return;
   if (state !== S.PLAYING && state !== S.BOSS && state !== S.DYING) return;
+  if (typeof updateEnv === 'function') updateEnv(dt);
   updateBuggy(dt);
+  if (typeof updateBullets === 'function') updateBullets(dt);
+  if (typeof updateEnemies === 'function') updateEnemies(dt);
+  if (typeof checkCollisions === 'function') checkCollisions();
+  if (typeof updatePowerups === 'function') updatePowerups(dt);
+  if (typeof updateParticles === 'function') updateParticles(dt);
+  if (typeof updateBoss === 'function' && state === S.BOSS) updateBoss(dt);
+  if (state === S.PLAYING) {
+    scrollX += buggy.vx * dt;
+    progress = Math.min(1, scrollX / PLANETS[planetIdx].patrolPx);
+    if (progress >= 1 && typeof startBoss === 'function') startBoss();
+  }
 }
 
 function draw() {
   const pl = PLANETS[planetIdx || 0];
-  ctx.fillStyle = pl.palette.sky;
-  ctx.fillRect(0, 0, W, H);
-  if (state === S.PLAYING || state === S.BOSS || state === S.DYING) {
-    drawBuggy();
+  switch (state) {
+    case S.TITLE:
+      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0,0,W,H);
+      drawStars(pl);
+      drawTitleScreen(pl);
+      break;
+    case S.GAME_OVER:
+      ctx.fillStyle = '#000'; ctx.fillRect(0,0,W,H);
+      drawGameOverScreen();
+      break;
+    case S.VICTORY:
+      ctx.fillStyle = '#000'; ctx.fillRect(0,0,W,H);
+      drawVictoryScreen();
+      break;
+    case S.PLANET_CLEAR:
+      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0,0,W,H);
+      drawStars(pl); drawGround(pl);
+      if (typeof drawPlanetClear === 'function') drawPlanetClear();
+      break;
+    case S.PLANET_INTRO:
+      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0,0,W,H);
+      drawStars(pl);
+      drawPlanetIntro(pl);
+      break;
+    default:
+      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0,0,W,H);
+      drawStars(pl); drawGround(pl);
+      if (typeof drawObstacles === 'function') drawObstacles();
+      if (typeof drawPowerups === 'function') drawPowerups();
+      if (typeof drawEnemies === 'function') drawEnemies();
+      if (typeof drawBullets === 'function') drawBullets();
+      drawBuggy();
+      if (typeof drawParticles === 'function') drawParticles();
+      if (typeof drawBoss === 'function' && state === S.BOSS) drawBoss();
+      if (typeof drawEnvOverlay === 'function') drawEnvOverlay();
+      if (state !== S.DYING) drawHUD();
+      if (state === S.PAUSED) drawPausedScreen();
+      break;
   }
+}
+
+function drawStars(pl) {
+  const seed1 = 12345, seed2 = 67890;
+  for (let i = 0; i < 80; i++) {
+    ctx.fillStyle = pl.palette.star;
+    const sx = ((seed1 * (i+1) * 7919) % 8000) - (scrollX * 0.15) % 8000;
+    const sy = ((seed1 * (i+1) * 3571) % (GROUND_Y - 60)) + 40;
+    ctx.fillRect(((sx % W) + W) % W, sy, 1 + (i%3===0?1:0), 1 + (i%3===0?1:0));
+  }
+  ctx.globalAlpha = 0.5;
+  for (let i = 0; i < 40; i++) {
+    ctx.fillStyle = pl.palette.star;
+    const sx = ((seed2 * (i+1) * 6271) % 8000) - (scrollX * 0.35) % 8000;
+    const sy = ((seed2 * (i+1) * 4127) % (GROUND_Y - 100)) + 60;
+    ctx.fillRect(((sx % W) + W) % W, sy, 2, 2);
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawGround(pl) {
+  ctx.fillStyle = pl.palette.groundFill;
+  ctx.fillRect(0, GROUND_Y, W, H - GROUND_Y);
+  ctx.fillStyle = pl.palette.groundTop;
+  ctx.fillRect(0, GROUND_Y, W, 4);
+}
+
+function startBoss() { state = S.BOSS; }
+
+function drawHUD() {
+  ctx.fillStyle = 'rgba(0,0,0,0.55)';
+  ctx.fillRect(0, 0, W, 44);
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 13px monospace';
+  ctx.fillText('SCORE ' + String(score).padStart(7,'0'), 12, 17);
+  ctx.fillStyle = '#ff9a3c';
+  ctx.fillText('HI ' + String(hiScore).padStart(7,'0'), 12, 32);
+  ctx.fillStyle = PLANETS[planetIdx].palette.text;
+  ctx.textAlign = 'center'; ctx.fillText(PLANETS[planetIdx].name, W/2, 17); ctx.textAlign = 'left';
+  ctx.fillStyle = '#ffd866';
+  ctx.fillText('LIVES ' + '♥'.repeat(Math.max(0,lives)), W - 140, 17);
+  const barX=80, barY=44, barW=W-160, barH=6;
+  ctx.fillStyle='#1a0900'; ctx.fillRect(barX,barY,barW,barH);
+  ctx.fillStyle=PLANETS[planetIdx].palette.groundTop; ctx.fillRect(barX,barY,barW*progress,barH);
+  ctx.fillStyle='#ff9a3c'; ctx.font='10px monospace';
+  ctx.fillText('A',barX-14,barY+7); ctx.fillText('Z',barX+barW+4,barY+7);
+  ctx.fillStyle='#c04020'; ctx.fillText('BOSS▸',barX+barW-36,barY-2);
+}
+
+function drawTitleScreen(pl) {
+  ctx.fillStyle = pl.palette.text;
+  ctx.font = 'bold 48px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('MOON PATROL', W/2, H/2 - 60);
+  ctx.font = 'bold 28px monospace';
+  ctx.fillStyle = '#ff9a3c';
+  ctx.fillText('// RECON //', W/2, H/2 - 10);
+  ctx.font = '16px monospace';
+  ctx.fillStyle = '#ffd866';
+  ctx.fillText('PRESS SPACE OR ENTER TO START', W/2, H/2 + 50);
+  ctx.font = '13px monospace';
+  ctx.fillStyle = pl.palette.star;
+  ctx.fillText('HI-SCORE  ' + String(hiScore).padStart(7,'0'), W/2, H/2 + 90);
+  ctx.textAlign = 'left';
+}
+
+function drawPlanetIntro(pl) {
+  ctx.fillStyle = pl.palette.text;
+  ctx.font = 'bold 36px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('PLANET: ' + pl.name, W/2, H/2 - 20);
+  ctx.font = '18px monospace';
+  ctx.fillStyle = '#ffd866';
+  ctx.fillText('PATROL COMMENCING...', W/2, H/2 + 30);
+  ctx.textAlign = 'left';
+}
+
+function drawGameOverScreen() {
+  ctx.fillStyle = '#ff4040';
+  ctx.font = 'bold 56px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('GAME OVER', W/2, H/2 - 40);
+  ctx.font = '20px monospace';
+  ctx.fillStyle = '#ffd866';
+  ctx.fillText('SCORE ' + String(score).padStart(7,'0'), W/2, H/2 + 20);
+  ctx.fillText('PRESS SPACE TO RESTART', W/2, H/2 + 60);
+  ctx.textAlign = 'left';
+}
+
+function drawVictoryScreen() {
+  ctx.fillStyle = '#ffd866';
+  ctx.font = 'bold 48px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('VICTORY!', W/2, H/2 - 40);
+  ctx.font = '20px monospace';
+  ctx.fillStyle = '#ff9a3c';
+  ctx.fillText('FINAL SCORE ' + String(score).padStart(7,'0'), W/2, H/2 + 20);
+  ctx.fillText('PRESS SPACE TO PLAY AGAIN', W/2, H/2 + 60);
+  ctx.textAlign = 'left';
+}
+
+function drawPausedScreen() {
+  ctx.fillStyle = 'rgba(0,0,0,0.6)';
+  ctx.fillRect(0, 0, W, H);
+  ctx.fillStyle = '#ffd866';
+  ctx.font = 'bold 40px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('PAUSED', W/2, H/2);
+  ctx.font = '16px monospace';
+  ctx.fillStyle = '#ff9a3c';
+  ctx.fillText('PRESS P TO RESUME', W/2, H/2 + 50);
+  ctx.textAlign = 'left';
 }
 
 initGame();

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -1,21 +1,65 @@
 (() => {
 'use strict';
 
+// ── canvas ──────────────────────────────────────────────────────────────────
 const W = 960, H = 640;
+const GROUND_Y = H - 80;
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 
+// ── state ────────────────────────────────────────────────────────────────────
+const S = { LOADING:'LOADING', TITLE:'TITLE', PLANET_INTRO:'PLANET_INTRO',
+            PLAYING:'PLAYING', BOSS:'BOSS', DYING:'DYING', PAUSED:'PAUSED',
+            PLANET_CLEAR:'PLANET_CLEAR', GAME_OVER:'GAME_OVER', VICTORY:'VICTORY' };
+let state = S.TITLE;
+
+// ── scoring ──────────────────────────────────────────────────────────────────
+const PTS = { ufo_scout:150, moon_tank:100, sand_crawler:100, dive_bomber:150,
+              ice_drone:150, cryo_turret:200, phantom_drone:150, orbital_mine:120,
+              boss:2000, crater_clear:10, planet_nodeath:1000 };
+
+// ── planets ──────────────────────────────────────────────────────────────────
+const PLANETS = [
+  { id:'moon',   name:'MOON',   gravity:360, envId:'low_gravity',
+    palette:{ sky:'#0d1020', groundTop:'#3a3a50', groundFill:'#20202e', star:'#c0c8d8', text:'#c8c8d0' },
+    enemies:['ufo_scout','moon_tank'], obstacles:['crater','lunar_rock'],
+    patrolPx:8000, bossId:'lunar_fortress' },
+  { id:'mars',   name:'MARS',   gravity:560, envId:'dust_storm',
+    palette:{ sky:'#1e0800', groundTop:'#7a2a00', groundFill:'#3a1200', star:'#c07040', text:'#e06030' },
+    enemies:['sand_crawler','dive_bomber'], obstacles:['ravine','rock_spire'],
+    patrolPx:9000, bossId:'storm_titan' },
+  { id:'europa', name:'EUROPA', gravity:480, envId:'ice_slide',
+    palette:{ sky:'#050d1a', groundTop:'#5080b0', groundFill:'#102040', star:'#a0d0ff', text:'#80c0ff' },
+    enemies:['ice_drone','cryo_turret'], obstacles:['crevasse','ice_wall'],
+    patrolPx:9500, bossId:'glacial_sentinel' },
+  { id:'void',   name:'THE VOID', gravity:-40, envId:'zero_g',
+    palette:{ sky:'#0a0018', groundTop:'#4a1a6a', groundFill:'#1a0030', star:'#b073ff', text:'#b073ff' },
+    enemies:['phantom_drone','orbital_mine'], obstacles:['void_gap'],
+    patrolPx:10000, bossId:'the_overseer' },
+];
+
+// ── game variables ────────────────────────────────────────────────────────────
+let planetIdx, score, lives, hiScore, progress, scrollX, frame;
+let deathOnThisPlanet;
+hiScore = parseInt(localStorage.getItem('mpr_hi') || '0');
+
+// ── loop ─────────────────────────────────────────────────────────────────────
 let lastTs = 0;
 function loop(ts) {
   const dt = Math.min((ts - lastTs) / 1000, 0.05);
   lastTs = ts;
-  ctx.clearRect(0, 0, W, H);
-  ctx.fillStyle = '#0a0500';
-  ctx.fillRect(0, 0, W, H);
-  // placeholder: white dot so we know the loop runs
-  ctx.fillStyle = '#fff';
-  ctx.fillRect(W/2, H/2, 4, 4);
+  frame = (frame || 0) + 1;
+  update(dt);
+  draw();
   requestAnimationFrame(loop);
 }
+
+function update(dt) { /* filled in Task 4 */ }
+function draw() {
+  const pl = PLANETS[planetIdx || 0];
+  ctx.fillStyle = pl.palette.sky;
+  ctx.fillRect(0, 0, W, H);
+}
+
 requestAnimationFrame(loop);
 })();

--- a/moonpatrol/game.js
+++ b/moonpatrol/game.js
@@ -42,6 +42,7 @@ const PLANETS = [
 let planetIdx, score, lives, hiScore, progress, scrollX, frame;
 let deathOnThisPlanet;
 let gravityReversed = false, gravRevTimer = 0;
+let paused = false;
 hiScore = parseInt(localStorage.getItem('mpr_hi') || '0');
 
 // ── input ────────────────────────────────────────────────────────────────────
@@ -49,8 +50,7 @@ const keys = {};
 window.addEventListener('keydown', e => {
   keys[e.code] = true;
   if (['Space','ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.code)) e.preventDefault();
-  if (e.code === 'KeyP' && state === S.PLAYING) state = S.PAUSED;
-  else if (e.code === 'KeyP' && state === S.PAUSED) state = S.PLAYING;
+  if (e.code === 'KeyP' && (state === S.PLAYING || state === S.BOSS)) paused = !paused;
   if ((e.code === 'Space' || e.code === 'Enter') && state === S.TITLE) initGame();
   if ((e.code === 'Space' || e.code === 'Enter') && (state === S.GAME_OVER || state === S.VICTORY)) initGame();
 });
@@ -62,7 +62,7 @@ let buggy;
 
 function initGame() {
   planetIdx = 0; score = 0; lives = 3; progress = 0; scrollX = 0; frame = 0;
-  deathOnThisPlanet = false;
+  deathOnThisPlanet = false; paused = false;
   obstacles = generateObstacles(0);
   bullets = [];
   enemies = []; spawnTimer = 0;
@@ -295,7 +295,7 @@ function loop(ts) {
 }
 
 function update(dt) {
-  if (state === S.PAUSED) return;
+  if (paused) return;
   if (state !== S.PLAYING && state !== S.BOSS && state !== S.DYING) return;
   if (typeof updateEnv === 'function') updateEnv(dt);
   updateBuggy(dt);
@@ -321,42 +321,38 @@ function draw() {
   const pl = PLANETS[planetIdx || 0];
   switch (state) {
     case S.TITLE:
-      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0,0,W,H);
-      drawStars(pl);
-      drawTitleScreen(pl);
+      drawTitle();
       break;
     case S.GAME_OVER:
-      ctx.fillStyle = '#000'; ctx.fillRect(0,0,W,H);
-      drawGameOverScreen();
+      drawGameOver();
       break;
     case S.VICTORY:
-      ctx.fillStyle = '#000'; ctx.fillRect(0,0,W,H);
-      drawVictoryScreen();
+      drawVictory();
       break;
     case S.PLANET_CLEAR:
-      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0,0,W,H);
-      drawStars(pl); drawGround(pl);
-      if (typeof drawPlanetClear === 'function') drawPlanetClear();
+      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0, 0, W, H);
+      if (typeof drawStars === 'function') drawStars(pl);
+      if (typeof drawGround === 'function') drawGround(pl);
+      drawPlanetClear();
       break;
     case S.PLANET_INTRO:
-      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0,0,W,H);
-      drawStars(pl);
-      drawPlanetIntro(pl);
+      if (typeof drawPlanetIntro === 'function') drawPlanetIntro();
       break;
-    default:
-      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0,0,W,H);
-      drawStars(pl); drawGround(pl);
-      drawObstacles();
+    default: {
+      ctx.fillStyle = pl.palette.sky; ctx.fillRect(0, 0, W, H);
+      if (typeof drawStars === 'function') drawStars(pl);
+      if (typeof drawGround === 'function') drawGround(pl);
+      if (typeof drawObstacles === 'function') drawObstacles();
       if (typeof drawPowerups === 'function') drawPowerups();
       if (typeof drawEnemies === 'function') drawEnemies();
-      drawBullets();
-      drawBuggy();
+      if (typeof drawBullets === 'function') drawBullets();
+      if (typeof drawBuggy === 'function') drawBuggy();
       if (typeof drawParticles === 'function') drawParticles();
-      if (typeof drawBoss === 'function' && state === S.BOSS) drawBoss();
+      if (typeof drawBoss === 'function') drawBoss();
       if (typeof drawEnvOverlay === 'function') drawEnvOverlay();
+      if (paused) drawPaused();
       if (state !== S.DYING) drawHUD();
-      if (state === S.PAUSED) drawPausedScreen();
-      break;
+    }
   }
 }
 
@@ -896,68 +892,78 @@ function drawHUD() {
   ctx.fillStyle='#c04020'; ctx.fillText('BOSS▸',barX+barW-36,barY-2);
 }
 
-function drawTitleScreen(pl) {
-  ctx.fillStyle = pl.palette.text;
-  ctx.font = 'bold 48px monospace';
+function drawTitle() {
+  const pl = PLANETS[0];
+  ctx.fillStyle = pl.palette.sky; ctx.fillRect(0, 0, W, H);
+  if (typeof drawStars === 'function') drawStars(pl);
   ctx.textAlign = 'center';
-  ctx.fillText('MOON PATROL', W/2, H/2 - 60);
-  ctx.font = 'bold 28px monospace';
-  ctx.fillStyle = '#ff9a3c';
-  ctx.fillText('// RECON //', W/2, H/2 - 10);
-  ctx.font = '16px monospace';
-  ctx.fillStyle = '#ffd866';
-  ctx.fillText('PRESS SPACE OR ENTER TO START', W/2, H/2 + 50);
-  ctx.font = '13px monospace';
-  ctx.fillStyle = pl.palette.star;
-  ctx.fillText('HI-SCORE  ' + String(hiScore).padStart(7,'0'), W/2, H/2 + 90);
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 48px monospace';
+  ctx.fillText('MOON PATROL', W/2, 220);
+  ctx.fillStyle = '#ff9a3c'; ctx.font = 'bold 18px monospace';
+  ctx.fillText('// RECON', W/2, 256);
+  if (Math.floor(Date.now() / 600) % 2 === 0) {
+    ctx.fillStyle = '#c8c8d0'; ctx.font = '14px monospace';
+    ctx.fillText('PRESS SPACE OR ENTER TO START', W/2, 340);
+  }
+  ctx.fillStyle = '#ff9a3c'; ctx.font = '12px monospace';
+  ctx.fillText('HI-SCORE  ' + String(hiScore).padStart(7,'0'), W/2, 380);
+  ctx.fillStyle = '#7a4000'; ctx.font = '11px monospace';
+  ctx.fillText('← → DRIVE   ↑ JUMP   Z FIRE   X MISSILE   P PAUSE', W/2, 430);
   ctx.textAlign = 'left';
 }
 
-function drawPlanetIntro(pl) {
-  ctx.fillStyle = pl.palette.text;
-  ctx.font = 'bold 36px monospace';
+function drawPlanetIntro() {
+  const pl = PLANETS[planetIdx];
+  ctx.fillStyle = pl.palette.sky; ctx.fillRect(0, 0, W, H);
+  if (typeof drawStars === 'function') drawStars(pl);
   ctx.textAlign = 'center';
-  ctx.fillText('PLANET: ' + pl.name, W/2, H/2 - 20);
-  ctx.font = '18px monospace';
-  ctx.fillStyle = '#ffd866';
-  ctx.fillText('PATROL COMMENCING...', W/2, H/2 + 30);
+  ctx.fillStyle = pl.palette.text; ctx.font = 'bold 52px monospace';
+  ctx.fillText(pl.name, W/2, H/2 - 20);
+  ctx.fillStyle = '#ff9a3c'; ctx.font = '13px monospace';
+  const descs = ['PATROL ZONE ALPHA — LOW GRAVITY', 'DUST STORM WARNING IN EFFECT', 'ICY TERRAIN — TRACTION REDUCED', 'GRAVITY ANOMALY DETECTED'];
+  ctx.fillText(descs[planetIdx] || '', W/2, H/2 + 30);
   ctx.textAlign = 'left';
 }
 
-function drawGameOverScreen() {
-  ctx.fillStyle = '#ff4040';
-  ctx.font = 'bold 56px monospace';
+function drawGameOver() {
+  ctx.fillStyle = 'rgba(0,0,0,0.80)'; ctx.fillRect(0, 0, W, H);
   ctx.textAlign = 'center';
-  ctx.fillText('GAME OVER', W/2, H/2 - 40);
-  ctx.font = '20px monospace';
-  ctx.fillStyle = '#ffd866';
-  ctx.fillText('SCORE ' + String(score).padStart(7,'0'), W/2, H/2 + 20);
-  ctx.fillText('PRESS SPACE TO RESTART', W/2, H/2 + 60);
+  ctx.fillStyle = '#c04020'; ctx.font = 'bold 42px monospace';
+  ctx.fillText('GAME OVER', W/2, H/2 - 50);
+  ctx.fillStyle = '#ffd866'; ctx.font = '18px monospace';
+  ctx.fillText('SCORE ' + String(score).padStart(7,'0'), W/2, H/2);
+  if (score >= hiScore && score > 0) { ctx.fillStyle = '#7dffae'; ctx.font = '14px monospace'; ctx.fillText('NEW HI-SCORE!', W/2, H/2 + 30); }
+  if (Math.floor(Date.now()/700) % 2 === 0) {
+    ctx.fillStyle = '#ff9a3c'; ctx.font = '13px monospace';
+    ctx.fillText('PRESS SPACE TO RETRY', W/2, H/2 + 70);
+  }
   ctx.textAlign = 'left';
 }
 
-function drawVictoryScreen() {
-  ctx.fillStyle = '#ffd866';
-  ctx.font = 'bold 48px monospace';
+function drawVictory() {
+  ctx.fillStyle = 'rgba(0,0,0,0.75)'; ctx.fillRect(0, 0, W, H);
   ctx.textAlign = 'center';
-  ctx.fillText('VICTORY!', W/2, H/2 - 40);
-  ctx.font = '20px monospace';
-  ctx.fillStyle = '#ff9a3c';
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 38px monospace';
+  ctx.fillText('MISSION COMPLETE', W/2, H/2 - 60);
+  ctx.fillStyle = '#7dffae'; ctx.font = '18px monospace';
+  ctx.fillText('ALL PLANETS CLEARED', W/2, H/2 - 20);
+  ctx.fillStyle = '#ffd866'; ctx.font = '16px monospace';
   ctx.fillText('FINAL SCORE ' + String(score).padStart(7,'0'), W/2, H/2 + 20);
-  ctx.fillText('PRESS SPACE TO PLAY AGAIN', W/2, H/2 + 60);
+  if (score >= hiScore && score > 0) { ctx.fillStyle = '#ff2bd6'; ctx.font = '14px monospace'; ctx.fillText('★ NEW HI-SCORE ★', W/2, H/2 + 55); }
+  if (Math.floor(Date.now()/700) % 2 === 0) {
+    ctx.fillStyle = '#ff9a3c'; ctx.font = '13px monospace';
+    ctx.fillText('PRESS SPACE TO PLAY AGAIN', W/2, H/2 + 90);
+  }
   ctx.textAlign = 'left';
 }
 
-function drawPausedScreen() {
-  ctx.fillStyle = 'rgba(0,0,0,0.6)';
-  ctx.fillRect(0, 0, W, H);
-  ctx.fillStyle = '#ffd866';
-  ctx.font = 'bold 40px monospace';
+function drawPaused() {
+  ctx.fillStyle = 'rgba(0,0,0,0.65)'; ctx.fillRect(0, 0, W, H);
   ctx.textAlign = 'center';
-  ctx.fillText('PAUSED', W/2, H/2);
-  ctx.font = '16px monospace';
-  ctx.fillStyle = '#ff9a3c';
-  ctx.fillText('PRESS P TO RESUME', W/2, H/2 + 50);
+  ctx.fillStyle = '#ffd866'; ctx.font = 'bold 28px monospace';
+  ctx.fillText('PAUSED', W/2, H/2 - 20);
+  ctx.fillStyle = '#ff9a3c'; ctx.font = '13px monospace';
+  ctx.fillText('PRESS P TO RESUME', W/2, H/2 + 20);
   ctx.textAlign = 'left';
 }
 

--- a/moonpatrol/images/README.md
+++ b/moonpatrol/images/README.md
@@ -1,0 +1,29 @@
+# Images
+
+All assets are free-use pixel art. Download and save with the filenames below.
+
+BUGGY
+  buggy.png (52×28)   — pixel art moon buggy, side view facing right
+  Source: Kenney "Space Shooter Redux" — https://kenney.nl/assets/space-shooter-redux
+
+UFO / AERIAL ENEMIES
+  ufo.png (36×18)           — flying saucer
+  dive_bomber.png (28×20)
+  ice_drone.png (30×20)
+  phantom_drone.png (32×24)
+  orbital_mine.png (20×20)  — spiky ball
+  Source: OpenGameArt "Space Shooter" by Kenney (CC0)
+
+GROUND ENEMIES
+  moon_tank.png (36×20)
+  sand_crawler.png (32×16)
+  cryo_turret.png (24×28)
+
+BOSSES
+  boss_lunar_fortress.png (180×80)
+  boss_storm_titan.png (160×120)
+  boss_glacial_sentinel.png (100×160)
+  boss_overseer.png (140×140)
+
+All assets should have transparent backgrounds (PNG-24 with alpha).
+White backgrounds are stripped automatically by keyWhite() in game.js.

--- a/moonpatrol/index.html
+++ b/moonpatrol/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>MOON PATROL // RECON</title>
+<style>
+  :root { --amber:#ff9a3c; --gold:#ffd866; --bg:#0a0500; }
+  *{ box-sizing:border-box; margin:0; padding:0; }
+  html,body{ width:100%;height:100%;overflow:hidden;
+    background:radial-gradient(ellipse at 50% 30%,#150900 0%,#0a0500 70%);
+    color:var(--amber);
+    font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace; cursor:default; }
+  #stage{ position:fixed;inset:0;display:grid;place-items:center; }
+  #game{ image-rendering:pixelated;image-rendering:-moz-crisp-edges;
+    image-rendering:crisp-edges;background:#000;
+    box-shadow:0 0 60px rgba(255,154,60,0.18),0 0 120px rgba(192,64,32,0.10);
+    border:1px solid rgba(255,154,60,0.25);max-width:100vw;max-height:100vh; }
+  #stage::after{ content:"";position:fixed;inset:0;pointer-events:none;
+    background:
+      repeating-linear-gradient(to bottom,rgba(0,0,0,0) 0px,rgba(0,0,0,0) 2px,
+        rgba(0,0,0,0.22) 3px,rgba(0,0,0,0) 4px),
+      radial-gradient(ellipse at center,rgba(0,0,0,0) 55%,rgba(0,0,0,0.55) 100%);
+    mix-blend-mode:multiply;z-index:5; }
+</style>
+</head>
+<body>
+  <div id="stage">
+    <canvas id="game" width="960" height="640"></canvas>
+  </div>
+  <script src="game.js"></script>
+</body>
+</html>

--- a/moonpatrol/sounds/README.md
+++ b/moonpatrol/sounds/README.md
@@ -1,0 +1,14 @@
+# Sounds
+
+Download these free sounds and save with the filenames below:
+
+cannon.wav  — a short laser/zap sound
+            freesound.org — search "laser zap" or "8-bit laser"
+            Suggestion: freesound.org/s/270343/ (8-bit laser, CC0)
+
+boom.wav    — explosion sound
+            freesound.org — search "8-bit explosion"
+            Suggestion: freesound.org/s/387232/ (retro explosion, CC0)
+
+The synthesised engine hum works without any downloaded files.
+The game gracefully skips missing audio files.


### PR DESCRIPTION
## Summary

- Adds a complete new game `moonpatrol/` — a retro CRT arcade horizontal side-scroller inspired by Moon Patrol (1982), entirely separate from the existing Alien // Eclipse game
- Moon buggy with dual forward + upward cannons crosses 4 planets (Moon → Mars → Europa → The Void), each with unique terrain, enemies, environmental mechanic (low gravity, dust storm, ice slide, zero-G), and a multi-phase boss fight
- Single-file HTML5 Canvas engine (`moonpatrol/game.js`, ~1150 lines): state machine, delta-time physics, deterministic obstacle generation, particle system, power-ups, Web Audio synthesized engine hum + SFX hooks, sprite loader with rectangle fallback, localStorage hi-score

## What's included

- **4 planets** with distinct palettes, enemy types, and environmental mechanics
- **4 bosses**: Lunar Fortress (hatch cycle), Storm Titan (dive + dust storm), Glacial Sentinel (ice walls + shockwave), The Overseer (gravity reversal, 4 phases)
- **8 enemy types**: UFO Scout, Moon Tank, Sand Crawler, Dive Bomber, Ice Drone, Cryo Turret, Phantom Drone, Orbital Mine
- **4 power-ups**: Rapid Fire, Shield, Missile (homing), Score ×2
- **Game screens**: Title, Planet Intro, Planet Clear, Game Over, Victory, Pause overlay
- **CRT aesthetic**: scanline + vignette CSS overlay, amber/gold palette
- `moonpatrol/images/README.md` and `moonpatrol/sounds/README.md` with free-use asset download instructions

## Test Plan

- [ ] Open `moonpatrol/index.html` in a browser — title screen appears with CRT scanlines
- [ ] Press Space → Moon planet intro shows for 2.5s, then gameplay begins
- [ ] Drive, jump craters, shoot enemies (Z = fire, X = missile, ↑ = jump, ↓ = Void thruster)
- [ ] Reach progress = 100% → boss fight triggers
- [ ] Defeat Moon boss → Mars planet intro → Mars gameplay
- [ ] On The Void (planet 4): gravity reversal flips buggy to ceiling for 5s in boss phase 2
- [ ] Die all 3 lives → Game Over screen, Space restarts from title
- [ ] Alien // Eclipse game (`index.html` at repo root) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)